### PR TITLE
[TURMA-00019] Background Page - Timeline behavior

### DIFF
--- a/src/app/background/page.view.tsx
+++ b/src/app/background/page.view.tsx
@@ -2,14 +2,16 @@ import UserInfo from "../../components/custom/UserInfo";
 import Timeline from "../../components/custom/Timeline";
 import "./styles.css"
 import ContentItem from "../../components/custom/ContentItem";
-import { contentData, listOfYears, userData } from "@/background-data";
+import { contentData, userData } from "@/background-data";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
-export default function UserPage() {
+export default function BackgroundPage() {
+  const backgroundYears = Array.from(new Set(contentData.map(item => item.year)));
+
   return (
     <main className="user-page-grid grid my-auto min-h-screen">
       <UserInfo {...userData}/>
-      <Timeline years={listOfYears} />
+      <Timeline years={backgroundYears} />
 
       <ScrollArea className="content-container scroll-area flex flex-col max-h-[290px]">
         {

--- a/src/components/custom/Timeline/README.md
+++ b/src/components/custom/Timeline/README.md
@@ -91,17 +91,17 @@ changeSelectedYear()
 
 ## Technical Decisions & Trade-offs
 
-### ✅ Why Inverted Scroll (base - scrollTop)?
+### Why Inverted Scroll (base - scrollTop)?
 - **Maintains alignment**: Bar visually stays with the year item as viewport scrolls
 - **Intuitive UX**: User sees the bar "follow" their selection
 - **Alternative rejected**: Fixed position would break out of ScrollArea context
 
-### ✅ Why Using Refs Instead of State Array?
+### Why Using Refs Instead of State Array?
 - **Performance**: Avoids recreating arrays on every render
 - **Direct DOM Access**: Enables getBoundingClientRect() for accurate positioning
 - **Memory Efficient**: Refs are mutable without triggering re-renders
 
-### ✅ Why Separate updateBarVisibility()?
+### Why Separate updateBarVisibility()?
 - **DRY Principle**: Logic used in both useEffect and scroll handler
 - **Testability**: Isolated function easier to unit test
 - **Maintainability**: Single source of truth for visibility logic
@@ -120,40 +120,20 @@ changeSelectedYear()
 - Bar moves inverse to scroll direction
 - Creates optical illusion of "sticking" to the selected year
 
-## Dependencies
-
-- **React Hooks**: `useState`, `useEffect`, `useRef`, `useCallback`
-- **Radix UI**: ScrollArea component
-- **Tailwind CSS**: Utility-based styling
-- **Custom Fonts**: `suseMono` from `@/lib/fonts`
-- **Utilities**: `cn()` for class merging
-
-## Files Modified
+## Files
 
 1. **`src/components/custom/Timeline/index.tsx`** (Main Component)
    - Scroll coordination
    - State management
    - Visibility detection
 
-2. **`src/components/custom/Timeline/types.ts`** (Type Definitions)
-   - TimelineItemProps
-   - YearButtonProps
-   - LeftCircleProps
-
-3. **`src/components/ui/scroll-area.tsx`** (Enhanced ScrollArea)
+2. **`src/components/ui/scroll-area.tsx`** (Enhanced ScrollArea)
    - Added `viewportRef` prop for ref attachment
    - Added `onViewportScroll` prop for scroll event handling
 
-4. **`src/app/background/page.view.tsx`** (Integration Point)
+3. **`src/app/background/page.view.tsx`** (Integration Point)
    - Extracts unique years from contentData
    - Passes to Timeline component
-
-## Performance Considerations
-
-- **Re-renders**: Only triggered on `selectedYear` or `years` changes
-- **Scroll Handler**: Lightweight calculations in `handleViewportScroll()`
-- **Ref Updates**: Don't trigger component re-renders
-- **Memoization**: Prevents unnecessary callback recreations
 
 ## Future Enhancement Opportunities
 

--- a/src/components/custom/Timeline/README.md
+++ b/src/components/custom/Timeline/README.md
@@ -1,0 +1,170 @@
+# Timeline Component - Implementation Summary
+
+## Overview
+The Timeline component is an interactive year selection interface with a smooth animated indicator bar that tracks the selected year, even when scrolling through the list.
+
+## Architecture & Key Features
+
+### 1. **Core State Management**
+- **`selectedYear`**: Tracks which year is currently selected (initialized to first year in array)
+- **`blackBorderYTranslation`**: Controls the vertical position of the indicator bar (the black one)
+- **`showBar`**: Controls visibility of the indicator bar (opacity toggle)
+- **`itemRefs`**: Map of refs to track DOM elements for visibility detection
+
+### 2. **Scroll Behavior - Inverted Translation**
+**Problem Solved**: When scrolling the ScrollArea, the indicator bar needed to move in the *opposite* direction to maintain visual alignment with the selected year.
+
+**Solution**: 
+```
+translation = base - scrollTop
+```
+- `base` = selected year index × 36px (year height)
+- `scrollTop` = current scroll position
+- By subtracting `scrollTop`, when user scrolls DOWN (+scrollTop), the bar moves UP (−translation)
+
+This creates the effect of the bar "staying with" the selected item as the user scrolls.
+
+### 3. **Visibility Detection & Animations**
+**Problem Solved**: The indicator bar should only be visible when the selected year is within the viewport boundaries.
+
+**Solution - `updateBarVisibility()` Function**:
+- Uses `getBoundingClientRect()` to compare:
+  - Viewport bounds: `viewportRef.getBoundingClientRect()`
+  - Item bounds: `itemRefs.current[selectedYear].getBoundingClientRect()`
+- Calculates visibility: `isVisible = item.bottom > viewport.top && item.top < viewport.bottom`
+- Sets `showBar(isVisible)` to trigger opacity transitions
+
+### 4. **Performance Optimizations**
+- **Memoized Callbacks**: `changeSelectedYear()` uses `useCallback` to prevent unnecessary re-renders
+- **Extracted Functions**: 
+  - `calculateBlackBorderTranslation()` - Pure function for position calculation
+  - `updateBarVisibility()` - Reusable visibility check logic
+  - `handleViewportScroll()` - Scroll handler aggregator
+- **No Inline Calculations**: Complex logic moved to named functions for clarity and reusability
+
+### 5. **Indicator Bar Animation**
+The bar uses Tailwind CSS transitions for smooth movement:
+```tsx
+transition-transform duration-300 ease-out
+transition-opacity duration-200
+```
+- Transform changes are animated smoothly over 300ms
+- Opacity changes (visibility) fade over 200ms
+- Uses `ease-out` for natural deceleration on position changes
+
+### 6. **Components Structure**
+
+#### **Timeline** (Main Component)
+- Manages state and scroll coordination
+- Renders `ScrollArea` with year items
+- Renders the indicator bar
+
+#### **YearButton** (Year Item)
+- Individual year selector
+- Shows/hides circle marker based on selection state
+- Background color changes when selected (`bg-accent-50`)
+- Transition animations for visual feedback
+
+#### **LeftCircle** (Selection Indicator)
+- Animated circle marker that appears next to selected year
+- Scales from 0 to 100% with opacity transition
+- Positioned absolutely with higher z-index
+
+### 7. **Data Flow**
+```
+ScrollArea Events
+    ↓
+handleViewportScroll()
+    ├→ Calculate translation (base - scrollTop)
+    ├→ Update bar position
+    └→ updateBarVisibility()
+         └→ setShowBar(isVisible)
+
+User Click on Year
+    ↓
+changeSelectedYear()
+    ├→ setSelectedYear(year)
+    ├→ useEffect triggers
+         ├→ Recalculate translation
+         └→ updateBarVisibility()
+```
+
+## Technical Decisions & Trade-offs
+
+### ✅ Why Inverted Scroll (base - scrollTop)?
+- **Maintains alignment**: Bar visually stays with the year item as viewport scrolls
+- **Intuitive UX**: User sees the bar "follow" their selection
+- **Alternative rejected**: Fixed position would break out of ScrollArea context
+
+### ✅ Why Using Refs Instead of State Array?
+- **Performance**: Avoids recreating arrays on every render
+- **Direct DOM Access**: Enables getBoundingClientRect() for accurate positioning
+- **Memory Efficient**: Refs are mutable without triggering re-renders
+
+### ✅ Why Separate updateBarVisibility()?
+- **DRY Principle**: Logic used in both useEffect and scroll handler
+- **Testability**: Isolated function easier to unit test
+- **Maintainability**: Single source of truth for visibility logic
+
+## Key Animations
+
+### 1. **Year Item Selection**
+- Background transitions to `bg-accent-50` over 300ms
+- Circle marker scales from 0 to 1 with fade-in
+
+### 2. **Indicator Bar Movement**
+- Smooth translateY animation following scroll and selection changes
+- Opacity fade when item exits viewport
+
+### 3. **Scroll Parallax Effect**
+- Bar moves inverse to scroll direction
+- Creates optical illusion of "sticking" to the selected year
+
+## Dependencies
+
+- **React Hooks**: `useState`, `useEffect`, `useRef`, `useCallback`
+- **Radix UI**: ScrollArea component
+- **Tailwind CSS**: Utility-based styling
+- **Custom Fonts**: `suseMono` from `@/lib/fonts`
+- **Utilities**: `cn()` for class merging
+
+## Files Modified
+
+1. **`src/components/custom/Timeline/index.tsx`** (Main Component)
+   - Scroll coordination
+   - State management
+   - Visibility detection
+
+2. **`src/components/custom/Timeline/types.ts`** (Type Definitions)
+   - TimelineItemProps
+   - YearButtonProps
+   - LeftCircleProps
+
+3. **`src/components/ui/scroll-area.tsx`** (Enhanced ScrollArea)
+   - Added `viewportRef` prop for ref attachment
+   - Added `onViewportScroll` prop for scroll event handling
+
+4. **`src/app/background/page.view.tsx`** (Integration Point)
+   - Extracts unique years from contentData
+   - Passes to Timeline component
+
+## Performance Considerations
+
+- **Re-renders**: Only triggered on `selectedYear` or `years` changes
+- **Scroll Handler**: Lightweight calculations in `handleViewportScroll()`
+- **Ref Updates**: Don't trigger component re-renders
+- **Memoization**: Prevents unnecessary callback recreations
+
+## Future Enhancement Opportunities
+
+1. **Sticky Mode**: Keep year fixed when scrolling out of viewport
+2. **Keyboard Navigation**: Arrow keys to select years
+3. **Smooth Scroll**: Auto-scroll to selected year on initial render
+4. **Content Integration**: Display year details in adjacent panel
+5. **Mobile Touch**: Swipe gestures for year selection
+
+---
+
+**Last Updated**: December 4, 2025  
+**Version**: 1.0  
+**Status**: Production Ready ✅

--- a/src/components/custom/Timeline/index.tsx
+++ b/src/components/custom/Timeline/index.tsx
@@ -5,9 +5,10 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { LeftCircleProps, TimelineItemProps, YearButtonProps } from "./types";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function Timeline({ years }: TimelineItemProps) {
+  const [blackBorderYTranslation, setBlackBorderYTranslation] = useState(0);
   const [selectedYear, setSelectedYear] = useState<number | null>(
     years && years.length > 0 ? years[0] : null
   );
@@ -16,21 +17,41 @@ export default function Timeline({ years }: TimelineItemProps) {
     setSelectedYear(yearSelected);
   }
 
+  // Atualiza a tradução Y da barra quando selectedYear mudar
+  useEffect(() => {
+    if (selectedYear == null) {
+      setBlackBorderYTranslation(0);
+      return;
+    }
+    const idx = years.indexOf(selectedYear);
+    const clampedIndex = idx >= 0 ? idx : 0;
+    setBlackBorderYTranslation(clampedIndex * 36);
+  }, [selectedYear, years]);
+
   return (
-    <ScrollArea className="z-1 timeline-container scroll-area flex flex-col max-h-[290px] ">
-      {years.map((year) => (
-        <YearButton
-          key={year}
-          year={year}
-          isSelected={year === selectedYear}
-          onClick={changeSelectedYear} />
-      ))}
-    </ScrollArea>
+    <div className="timeline-container flex">
+      <ScrollArea className="z-1 scroll-area flex flex-col max-h-[290px] ">
+        {years.map((year) => (
+          <YearButton
+            key={year}
+            year={year}
+            isSelected={year === selectedYear}
+            onClick={changeSelectedYear}
+          />
+        ))}
+      </ScrollArea>
+      <div
+        className="z-2 h-[36px] w-[3px] bg-zinc-900 -translate-x-[20px] text-transparent"
+        style={{ transform: `translateY(${blackBorderYTranslation}px)` }}
+      >
+        a
+      </div>
+    </div>
   );
 }
 
 function YearButton({ year, isSelected = false, onClick }: YearButtonProps) {
-  const selectedStyle = "bg-accent-50 border-r-[3px] border-r-zinc-900 -translate-x-[10px]";
+  const selectedStyle = "bg-accent-50";
   const selectedButtonStyle = "bg-accent-50";
 
   function handleOnSelectedYear(year: number) {
@@ -38,17 +59,22 @@ function YearButton({ year, isSelected = false, onClick }: YearButtonProps) {
   }
 
   return (
-    <div className={cn("flex items-center mr-[12px] translate-x-[10px]", isSelected && selectedStyle)}>
+    <div
+      className={cn(
+        "flex items-center mr-[12px] -translate-x-[10px]",
+        isSelected && selectedStyle
+      )}
+    >
       <LeftCircle isVisible={isSelected} />
       <Button
         variant="ghost"
         key={year}
         onClick={() => handleOnSelectedYear(year)}
-        className={
-          cn("pr-[8px] rounded-none border-zinc-100 border-l-[3px] cursor-pointer",
-            isSelected && selectedButtonStyle
-          )
-        }
+        aria-pressed={isSelected}
+        className={cn(
+          "pr-[8px] rounded-none border-zinc-100 border-l-[3px] cursor-pointer",
+          isSelected && selectedButtonStyle
+        )}
       >
         <span className={`text-[18px] ${suseMono.variable}`}>{year}</span>
       </Button>
@@ -58,13 +84,14 @@ function YearButton({ year, isSelected = false, onClick }: YearButtonProps) {
 
 function LeftCircle({ isVisible }: LeftCircleProps) {
   return (
-    <div className={
-      cn("relative -right-[12px] z-[999] flex items-center justify-center w-5 h-5",
-        !isVisible && "hidden"
-      )
-    }>
+    <div
+      className={cn(
+        "relative -right-[12px] z-[999] flex items-center justify-center w-5 h-5 transform-gpu transition-all duration-200 ease-out",
+        isVisible ? "scale-100 opacity-100" : "scale-0 opacity-0"
+      )}
+    >
       <div className="absolute w-2 h-2 rounded-full bg-primary"></div>
       <div className="absolute w-4 h-4 rounded-full border-2 border-primary"></div>
     </div>
-  )
+  );
 }

--- a/src/components/custom/Timeline/index.tsx
+++ b/src/components/custom/Timeline/index.tsx
@@ -1,27 +1,31 @@
+"use client"
+
 import { suseMono } from "@/lib/fonts";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
-import { TimelineItemProps, YearButtonProps } from "./types";
+import { LeftCircleProps, TimelineItemProps, YearButtonProps } from "./types";
+import { useState } from "react";
 
 export default function Timeline({ years }: TimelineItemProps) {
+  const [ selectedYear, setSelectedYear ] = useState<number>(years[3])
+
   return (
-    <ScrollArea className="z-1 timeline-container scroll-area flex flex-col max-h-[290px]">
+    <ScrollArea className="z-1 timeline-container scroll-area flex flex-col max-h-[290px] ">
       {years.map((year) => (
-        <YearButton key={year} year={year} />
+        <YearButton key={year} year={year} isSelected={year === selectedYear}/>
       ))}
     </ScrollArea>
   );
 }
 
-function YearButton({ year }: YearButtonProps) {
-  const isSelected = true;
-  const selectedStyle = "bg-accent-50 border-r-[3px] border-r-zinc-900 mr-[12px]";
+function YearButton({ year, isSelected = false }: YearButtonProps) {
+  const selectedStyle = "bg-accent-50 border-r-[3px] border-r-zinc-900 -translate-x-[10px]";
   const selectedButtonStyle = "bg-accent-50";
 
   return (
-    <div className={cn("flex items-center", isSelected && selectedStyle)}>
-      {isSelected && <LeftCircle />}
+    <div className={cn("flex items-center mr-[12px] translate-x-[10px]", isSelected && selectedStyle)}>
+      <LeftCircle isVisible={isSelected} />
       <Button
         variant="ghost"
         key={year}
@@ -33,9 +37,9 @@ function YearButton({ year }: YearButtonProps) {
   );
 }
 
-function LeftCircle() {
+function LeftCircle({ isVisible }: LeftCircleProps) {
   return (
-    <div className="relative -right-[12px] z-[999] flex items-center justify-center w-5 h-5">
+    <div className={cn("relative -right-[12px] z-[999] flex items-center justify-center w-5 h-5", !isVisible && "hidden")}>
       <div className="absolute w-2 h-2 rounded-full bg-primary"></div>
       <div className="absolute w-4 h-4 rounded-full border-2 border-primary"></div>
     </div>

--- a/src/components/custom/Timeline/index.tsx
+++ b/src/components/custom/Timeline/index.tsx
@@ -5,13 +5,16 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { LeftCircleProps, TimelineItemProps, YearButtonProps } from "./types";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export default function Timeline({ years }: TimelineItemProps) {
   const [blackBorderYTranslation, setBlackBorderYTranslation] = useState(0);
   const [selectedYear, setSelectedYear] = useState<number | null>(
     years && years.length > 0 ? years[0] : null
   );
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const itemRefs = useRef<Record<number, HTMLDivElement | null>>({});
+  const [showBar, setShowBar] = useState(true);
 
   const changeSelectedYear = useCallback((yearSelected: number) => {
     setSelectedYear(yearSelected);
@@ -25,16 +28,48 @@ export default function Timeline({ years }: TimelineItemProps) {
     return Math.max(0, idx) * yearHeight;
   }
 
+  function updateBarVisibility() {
+    if (viewportRef.current && selectedYear != null) {
+      const vp = viewportRef.current.getBoundingClientRect();
+      const item = itemRefs.current[selectedYear];
+      if (item) {
+        const it = item.getBoundingClientRect();
+        const isVisible = it.bottom > vp.top && it.top < vp.bottom;
+        setShowBar(isVisible);
+      } else {
+        setShowBar(false);
+      }
+    } else {
+      setShowBar(false);
+    }
+  }
+
+  function handleViewportScroll() {
+    const base = calculateBlackBorderTranslation(selectedYear, years);
+    const scrollTop = viewportRef.current ? viewportRef.current.scrollTop : 0;
+    setBlackBorderYTranslation(Math.max(0, base - scrollTop));
+
+    // Update visibility when scrolling
+    updateBarVisibility();
+  }
+
   useEffect(() => {
-    setBlackBorderYTranslation(
-      calculateBlackBorderTranslation(selectedYear, years)
-    );
+    const base = calculateBlackBorderTranslation(selectedYear, years);
+    const scrollTop = viewportRef.current ? viewportRef.current.scrollTop : 0;
+    // Invert scroll variation: when user scrolls down (scrollTop increases)
+    // the bar should move up => subtract scrollTop from base.
+    setBlackBorderYTranslation(Math.max(0, base - scrollTop));
+
+    // Check if the selected item is visible within the viewport
+    updateBarVisibility();
   }, [selectedYear, years]);
 
   return (
     <div className="timeline-container flex">
       <ScrollArea
         className="z-1 scroll-area flex flex-col max-h-[290px]"
+        viewportRef={viewportRef}
+        onViewportScroll={handleViewportScroll}
       >
         {years.map((year) => (
           <YearButton
@@ -42,11 +77,14 @@ export default function Timeline({ years }: TimelineItemProps) {
             year={year}
             isSelected={year === selectedYear}
             onClick={changeSelectedYear}
+            innerRef={(el) => (itemRefs.current[year] = el)}
           />
         ))}
       </ScrollArea>
       <div
-        className="z-2 h-[36px] w-[3px] bg-zinc-900 -translate-x-[20px] text-transparent transition-transform duration-300 ease-out"
+        className={`z-2 h-[36px] w-[3px] bg-zinc-900 -translate-x-[20px] text-transparent transition-transform duration-300 ease-out transition-opacity duration-200 ${
+          showBar ? "opacity-100" : "opacity-0 pointer-events-none"
+        }`}
         style={{ transform: `translateY(${blackBorderYTranslation}px)` }}
       >
         a
@@ -55,14 +93,15 @@ export default function Timeline({ years }: TimelineItemProps) {
   );
 }
 
-function YearButton({ year, isSelected = false, onClick }: YearButtonProps) {
+function YearButton({ year, isSelected = false, onClick, innerRef }: YearButtonProps) {
   const selectedStyle = "bg-accent-50";
   const selectedButtonStyle = "bg-accent-50";
 
   return (
     <div
+      ref={(el) => innerRef?.(el)}
       className={cn(
-        "flex items-center mr-[12px] -translate-x-[10px]",
+        "flex items-center mr-[12px] -translate-x-[10px] transition-all duration-300",
         isSelected && selectedStyle
       )}
     >

--- a/src/components/custom/Timeline/index.tsx
+++ b/src/components/custom/Timeline/index.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { LeftCircleProps, TimelineItemProps, YearButtonProps } from "./types";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export default function Timeline({ years }: TimelineItemProps) {
   const [blackBorderYTranslation, setBlackBorderYTranslation] = useState(0);
@@ -13,24 +13,29 @@ export default function Timeline({ years }: TimelineItemProps) {
     years && years.length > 0 ? years[0] : null
   );
 
-  function changeSelectedYear(yearSelected: number) {
+  const changeSelectedYear = useCallback((yearSelected: number) => {
     setSelectedYear(yearSelected);
+  }, []);
+
+  function calculateBlackBorderTranslation(selectedYear: number | null, years: number[]) {
+    const yearHeight = 36
+
+    if (selectedYear == null) return 0;
+    const idx = years.indexOf(selectedYear);
+    return Math.max(0, idx) * yearHeight;
   }
 
-  // Atualiza a tradução Y da barra quando selectedYear mudar
   useEffect(() => {
-    if (selectedYear == null) {
-      setBlackBorderYTranslation(0);
-      return;
-    }
-    const idx = years.indexOf(selectedYear);
-    const clampedIndex = idx >= 0 ? idx : 0;
-    setBlackBorderYTranslation(clampedIndex * 36);
+    setBlackBorderYTranslation(
+      calculateBlackBorderTranslation(selectedYear, years)
+    );
   }, [selectedYear, years]);
 
   return (
     <div className="timeline-container flex">
-      <ScrollArea className="z-1 scroll-area flex flex-col max-h-[290px] ">
+      <ScrollArea
+        className="z-1 scroll-area flex flex-col max-h-[290px]"
+      >
         {years.map((year) => (
           <YearButton
             key={year}
@@ -41,7 +46,7 @@ export default function Timeline({ years }: TimelineItemProps) {
         ))}
       </ScrollArea>
       <div
-        className="z-2 h-[36px] w-[3px] bg-zinc-900 -translate-x-[20px] text-transparent"
+        className="z-2 h-[36px] w-[3px] bg-zinc-900 -translate-x-[20px] text-transparent transition-transform duration-300 ease-out"
         style={{ transform: `translateY(${blackBorderYTranslation}px)` }}
       >
         a
@@ -54,10 +59,6 @@ function YearButton({ year, isSelected = false, onClick }: YearButtonProps) {
   const selectedStyle = "bg-accent-50";
   const selectedButtonStyle = "bg-accent-50";
 
-  function handleOnSelectedYear(year: number) {
-    onClick(year)
-  }
-
   return (
     <div
       className={cn(
@@ -68,8 +69,7 @@ function YearButton({ year, isSelected = false, onClick }: YearButtonProps) {
       <LeftCircle isVisible={isSelected} />
       <Button
         variant="ghost"
-        key={year}
-        onClick={() => handleOnSelectedYear(year)}
+        onClick={() => onClick(year)}
         aria-pressed={isSelected}
         className={cn(
           "pr-[8px] rounded-none border-zinc-100 border-l-[3px] cursor-pointer",

--- a/src/components/custom/Timeline/index.tsx
+++ b/src/components/custom/Timeline/index.tsx
@@ -8,20 +8,34 @@ import { LeftCircleProps, TimelineItemProps, YearButtonProps } from "./types";
 import { useState } from "react";
 
 export default function Timeline({ years }: TimelineItemProps) {
-  const [ selectedYear, setSelectedYear ] = useState<number>(years[3])
+  const [selectedYear, setSelectedYear] = useState<number | null>(
+    years && years.length > 0 ? years[0] : null
+  );
+
+  function changeSelectedYear(yearSelected: number) {
+    setSelectedYear(yearSelected);
+  }
 
   return (
     <ScrollArea className="z-1 timeline-container scroll-area flex flex-col max-h-[290px] ">
       {years.map((year) => (
-        <YearButton key={year} year={year} isSelected={year === selectedYear}/>
+        <YearButton
+          key={year}
+          year={year}
+          isSelected={year === selectedYear}
+          onClick={changeSelectedYear} />
       ))}
     </ScrollArea>
   );
 }
 
-function YearButton({ year, isSelected = false }: YearButtonProps) {
+function YearButton({ year, isSelected = false, onClick }: YearButtonProps) {
   const selectedStyle = "bg-accent-50 border-r-[3px] border-r-zinc-900 -translate-x-[10px]";
   const selectedButtonStyle = "bg-accent-50";
+
+  function handleOnSelectedYear(year: number) {
+    onClick(year)
+  }
 
   return (
     <div className={cn("flex items-center mr-[12px] translate-x-[10px]", isSelected && selectedStyle)}>
@@ -29,7 +43,12 @@ function YearButton({ year, isSelected = false }: YearButtonProps) {
       <Button
         variant="ghost"
         key={year}
-        className={cn("pr-[8px] rounded-none border-zinc-100 border-l-[3px]", isSelected && selectedButtonStyle)}
+        onClick={() => handleOnSelectedYear(year)}
+        className={
+          cn("pr-[8px] rounded-none border-zinc-100 border-l-[3px] cursor-pointer",
+            isSelected && selectedButtonStyle
+          )
+        }
       >
         <span className={`text-[18px] ${suseMono.variable}`}>{year}</span>
       </Button>
@@ -39,7 +58,11 @@ function YearButton({ year, isSelected = false }: YearButtonProps) {
 
 function LeftCircle({ isVisible }: LeftCircleProps) {
   return (
-    <div className={cn("relative -right-[12px] z-[999] flex items-center justify-center w-5 h-5", !isVisible && "hidden")}>
+    <div className={
+      cn("relative -right-[12px] z-[999] flex items-center justify-center w-5 h-5",
+        !isVisible && "hidden"
+      )
+    }>
       <div className="absolute w-2 h-2 rounded-full bg-primary"></div>
       <div className="absolute w-4 h-4 rounded-full border-2 border-primary"></div>
     </div>

--- a/src/components/custom/Timeline/types.ts
+++ b/src/components/custom/Timeline/types.ts
@@ -6,6 +6,7 @@ export type YearButtonProps = {
   year: number;
   isSelected: boolean;
   onClick: (year: number) => void;
+  innerRef?: (el: HTMLDivElement | null) => void;
 }
 
 export type LeftCircleProps = {

--- a/src/components/custom/Timeline/types.ts
+++ b/src/components/custom/Timeline/types.ts
@@ -4,4 +4,10 @@ export type TimelineItemProps = {
 
 export type YearButtonProps = {
   year: number;
+  isSelected: boolean;
+  onSelect?: (year: number) => void;
+}
+
+export type LeftCircleProps = {
+  isVisible: boolean;
 }

--- a/src/components/custom/Timeline/types.ts
+++ b/src/components/custom/Timeline/types.ts
@@ -5,7 +5,7 @@ export type TimelineItemProps = {
 export type YearButtonProps = {
   year: number;
   isSelected: boolean;
-  onSelect?: (year: number) => void;
+  onClick: (year: number) => void;
 }
 
 export type LeftCircleProps = {

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -5,11 +5,18 @@ import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
 
 import { cn } from "@/lib/utils"
 
+type ScrollAreaProps = React.ComponentProps<typeof ScrollAreaPrimitive.Root> & {
+  viewportRef?: React.Ref<HTMLDivElement>;
+  onViewportScroll?: (e: React.UIEvent<HTMLDivElement>) => void;
+};
+
 function ScrollArea({
   className,
   children,
+  viewportRef,
+  onViewportScroll,
   ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+}: ScrollAreaProps) {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
@@ -18,6 +25,8 @@ function ScrollArea({
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
+        ref={viewportRef}
+        onScroll={onViewportScroll}
         className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
       >
         {children}


### PR DESCRIPTION
closes #19 

## Description

Adjusts on <Timeline /> component bahavior

- Filter background data to use only `year`s property, without repetition
- Start use useState to control which year is selected
- When clicked on a `<YearButton />` this must turn active (isSelected)
- Fix X position difference between non selected years and selected one
- Sync selected year with black border and timeline scroll (of `<ScrollArea/>`)
- Add a README for detail Timeline behavior

## Evidences

![timeline2](https://github.com/user-attachments/assets/b016d4f1-a28f-41e7-bd56-b3f9737c8083)
OBS: in that gif, the left gray bar disapear sometimes, this is a bug off screen capture program, not of the Timeline

X Position bug [fixed]
<img width="1048" height="739" alt="Image" src="https://github.com/user-attachments/assets/6b912dc7-e15f-49cf-a772-b82c4a3145c2" />
