### PR TITLE
[TURMA-00044] Background page - Increase ContentArea's height

### DIFF
--- a/src/background-data.ts
+++ b/src/background-data.ts
@@ -25,14 +25,6 @@ export type Background = {
 
 type UserBackground = Background[];
 
-function generateUUID(): string {
-  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
-    const r = (Math.random() * 16) | 0;
-    const v = c === "x" ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-}
-
 export const listOfYears = [
   1997, 2016, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025,
 ];
@@ -50,7 +42,7 @@ export const userData: UserInfo = {
 
 export const contentData: UserBackground = [
   {
-    id: generateUUID(),
+    id: "bg-1997-09",
     year: 1997,
     month: 9,
     title: "Era uma vez 🚩",
@@ -58,14 +50,14 @@ export const contentData: UserBackground = [
     location: "Salvador/BA",
   },
   {
-    id: generateUUID(),
+    id: "bg-2013-02",
     year: 2013,
     month: 2,
     title: "Ensino médio",
     description: "primeiro contato com programação \n - HTML e CSS",
   },
   {
-    id: generateUUID(),
+    id: "bg-2016-03",
     year: 2016,
     month: 3,
     title: "Ingressou na Universidade Federal do Ceará ✈️",
@@ -73,14 +65,14 @@ export const contentData: UserBackground = [
     location: "Fortaleza/CE",
   },
   {
-    id: generateUUID(),
+    id: "bg-2016-06",
     year: 2016,
     month: 6,
     title: "Trainee CoDi Jr. ❤️💚💙",
     description: "entrou na empresa júnior do SMD",
   },
   {
-    id: generateUUID(),
+    id: "bg-2018-04",
     year: 2018,
     month: 4,
     title: "Entrou para a diretoria 🥸",
@@ -88,7 +80,7 @@ export const contentData: UserBackground = [
     durationInMonths: 8,
   },
   {
-    id: generateUUID(),
+    id: "bg-2018-08",
     year: 2018,
     month: 8,
     title: "Estágio frontend - JGV",
@@ -96,7 +88,7 @@ export const contentData: UserBackground = [
     durationInMonths: 12,
   },
   {
-    id: generateUUID(),
+    id: "bg-2019-08",
     year: 2019,
     month: 8,
     title: "Jr. Developer - JGV 🤓",
@@ -111,7 +103,7 @@ export const contentData: UserBackground = [
     ],
   },
   {
-    id: generateUUID(),
+    id: "bg-2020-10",
     year: 2020,
     month: 10,
     title: "UX Developer - Ootz 🛍️",
@@ -120,7 +112,7 @@ export const contentData: UserBackground = [
     durationInMonths: 6,
   },
   {
-    id: generateUUID(),
+    id: "bg-2021-04",
     year: 2021,
     month: 4,
     title: "Dev Jr Flutter / Designer UI - bHave 📲",
@@ -140,7 +132,7 @@ export const contentData: UserBackground = [
     ],
   },
   {
-    id: generateUUID(),
+    id: "bg-2021-08",
     year: 2021,
     month: 8,
     title: "Software Engineer - Levva 💛🖤💛",
@@ -156,7 +148,7 @@ export const contentData: UserBackground = [
     ],
   },
   {
-    id: generateUUID(),
+    id: "bg-2022-12a",
     year: 2022,
     month: 12,
     title: "O diploma veio aí! 🎓",
@@ -174,7 +166,7 @@ export const contentData: UserBackground = [
     ],
   },
   {
-    id: generateUUID(),
+    id: "bg-2022-12b",
     year: 2022,
     month: 12,
     title: "Ingressou no Ignite 🚀",
@@ -187,7 +179,7 @@ export const contentData: UserBackground = [
     ],
   },
   {
-    id: generateUUID(),
+    id: "bg-2023-03",
     year: 2023,
     month: 3,
     title: "Primeira produção de conteúdo 🎥",
@@ -204,7 +196,7 @@ export const contentData: UserBackground = [
     ],
   },
   {
-    id: generateUUID(),
+    id: "bg-2023-06",
     year: 2023,
     month: 6,
     title: "Ingressou no curso.dev 📝",
@@ -217,7 +209,7 @@ export const contentData: UserBackground = [
     ],
   },
   {
-    id: generateUUID(),
+    id: "bg-2024-12",
     year: 2024,
     month: 12,
     title: "Especialista em React e Next.js🏅",
@@ -234,7 +226,7 @@ export const contentData: UserBackground = [
     ],
   },
   {
-    id: generateUUID(),
+    id: "bg-2025-01",
     year: 2025,
     month: 1,
     title: "Iniciou os estudos em Web3 e Open Source 🌐",

--- a/src/components/custom/ContentArea/ContentArea.tsx
+++ b/src/components/custom/ContentArea/ContentArea.tsx
@@ -5,21 +5,15 @@ import BulletList from "./BulletList";
 import { ContentList } from "./ContentList";
 
 export default function ContentArea() {
-  const {
-    selectedYear,
-  } = useBackground();
+  const { selectedYear } = useBackground();
 
   return (
-    <div
-      className="content-area flex flex-col self-start md:pl-6 max-h-[290px] h-[290px]"
-    >
+    <div className="content-area flex flex-col self-start md:pl-6 max-h-[290px] h-[290px]">
       <h1 className="text-3xl pb-4 mb-6 sticky top-0 z-10 bg-white shadow-xs">
         {selectedYear}
       </h1>
 
-      <div
-        className="content-view flex justify-between max-h-[200px] h-[200px] "
-      >
+      <div className="content-view flex justify-between max-h-[230px] h-[230px]">
         <ContentList />
         <BulletList />
       </div>

--- a/src/components/custom/ContentArea/ContentItem.tsx
+++ b/src/components/custom/ContentArea/ContentItem.tsx
@@ -1,15 +1,15 @@
 "use client";
 
 import { courstardSans } from "@/lib/fonts";
-import {
-  ContentItemProps,
-  ColorKey,
-} from "./content-item.types";
+import { ContentItemProps } from "./content-item.types";
 import { cn } from "@/lib/utils";
-import { useEffect, useRef, useMemo } from "react";
+import { useEffect, useRef, useMemo, forwardRef } from "react";
 import ProjectsList from "./ProjectList";
 import MonthBullet from "./MonthBullet";
-import { calculatePaddingNeeded, DEFAULT_CONTAINER_HEIGHT } from "./content-item.utils";
+import {
+  calculatePaddingNeeded,
+  DEFAULT_CONTAINER_HEIGHT,
+} from "./content-item.utils";
 import PeriodInfo from "./PeriodInfo";
 
 /**
@@ -27,98 +27,116 @@ import PeriodInfo from "./PeriodInfo";
  * - ResizeObserver for responsive layout adjustments
  */
 
-export default function ContentItem({
-  background,
-  isNotUniqueOrLast,
-  color,
-  isNext,
-  isPrevious,
-  isLastItem = false,
-  containerHeight = DEFAULT_CONTAINER_HEIGHT,
-}: ContentItemProps) {
-  const {
-    id,
-    month,
-    title,
-    description,
-    location,
-    durationInMonths,
-    projects,
-  } = background;
+const ContentItem = forwardRef<HTMLLIElement, ContentItemProps>((props, forwardedRef) => {
+    const {
+      background,
+      isNotUniqueOrLast,
+      color,
+      isNext,
+      isPrevious,
+      isLastItem = false,
+      containerHeight = DEFAULT_CONTAINER_HEIGHT,
+    } = props;
 
-  const contentItemRef = useRef<HTMLLIElement>(null);
+    const {
+      id,
+      month,
+      title,
+      description,
+      location,
+      durationInMonths,
+      projects,
+    } = background;
 
-  // Determine visual state based on position (next, previous, current)
-  const visualState = useMemo(() => {
-    const isInactive = isNext || isPrevious;
+    const internalRef = useRef<HTMLLIElement>(null);
 
-    return {
-      opacity: isInactive ? "opacity-30" : "opacity-100",
-      transition: "transition-opacity duration-300",
-      isInactive,
-    };
-  }, [isNext, isPrevious]);
+    // Determine visual state based on position (next, previous, current)
+    const visualState = useMemo(() => {
+      const isInactive = isNext || isPrevious;
 
-  const { opacity, transition } = visualState;
+      return {
+        opacity: isInactive ? "opacity-30" : "opacity-100",
+        transition: "transition-opacity duration-300",
+        isInactive,
+      };
+    }, [isNext, isPrevious]);
 
-  // Calculate padding for the last item
-  useEffect(() => {
-    if (!isLastItem || !contentItemRef.current) return;
+    const { opacity, transition } = visualState;
 
-    const updatePadding = () => {
-      if (!contentItemRef.current) return;
+    // Helper to combine internal ref with forwarded ref
+    const setItemRef = (element: HTMLLIElement | null) => {
+      internalRef.current = element; // Set internal ref
 
-      // Calculate needed padding
-      const paddingNeeded = calculatePaddingNeeded(
-        contentItemRef.current.offsetHeight,
-        containerHeight
-      );
-
-      // If the item is smaller than the available space, add padding
-      if (paddingNeeded > 0) {
-        contentItemRef.current.style.paddingBottom = `${paddingNeeded}px`;
+      if (typeof forwardedRef === "function") {
+        forwardedRef(element); // Call the function if it's a callback ref
+      } else if (forwardedRef) { // Assign to .current if it's a RefObject
+        forwardedRef.current = element;
       }
     };
 
-    // Execute after rendering
-    updatePadding();
+    // Calculate padding for the last item
+    useEffect(() => {
+      if (!isLastItem || !internalRef.current) return;
 
-    // Observe size changes to adjust padding dynamically every time the size changes (e.g., window resize or content changes)
-    const resizeObserver = new ResizeObserver(updatePadding);
-    resizeObserver.observe(contentItemRef.current);
+      const updatePadding = () => {
+        if (!internalRef.current) return;
 
-    return () => resizeObserver.disconnect();
-  }, [isLastItem, containerHeight]);
+        // Calculate needed padding
+        const paddingNeeded = calculatePaddingNeeded(
+          internalRef.current.offsetHeight,
+          containerHeight,
+        );
 
-  return (
-    <li
-      id={id}
-      ref={contentItemRef}
-      className={cn(
-        "flex flex-col items-start justify-between text-gray-400 txt-xs",
-        courstardSans.className,
-        opacity,
-        transition,
-        isNotUniqueOrLast && "mb-8",
-      )}
-    >
-      {month && (
-        <MonthBullet
-          color={color as ColorKey}
-          month={month}
-          isGrayScale={isNext}
+        // If the item is smaller than the available space, add padding
+        if (paddingNeeded > 0) {
+          internalRef.current.style.paddingBottom = `${paddingNeeded}px`;
+        }
+      };
+
+      // Execute after rendering
+      updatePadding();
+
+      // Observe size changes to adjust padding dynamically every time the size changes (e.g., window resize or content changes)
+      const resizeObserver = new ResizeObserver(updatePadding);
+      resizeObserver.observe(internalRef.current);
+
+      return () => resizeObserver.disconnect();
+    }, [isLastItem, containerHeight]);
+
+    return (
+      <li
+        id={id}
+        ref={setItemRef}
+        className={cn(
+          "flex flex-col items-start justify-between text-gray-400 txt-xs",
+          courstardSans.className,
+          opacity,
+          transition,
+          isNotUniqueOrLast && "mb-8",
+        )}
+      >
+        {month && (
+          <MonthBullet
+            color={color}
+            month={month}
+            isGrayScale={isNext}
+          />
+        )}
+
+        <PeriodInfo
+          title={title}
+          description={description}
+          location={location}
+          durationInMonths={durationInMonths}
+          isInactive={isNext || isPrevious}
         />
-      )}
 
-      <PeriodInfo
-        title={title}
-        description={description}
-        location={location}
-        durationInMonths={durationInMonths}
-        isInactive={isNext || isPrevious}
-      />
+        {projects && <ProjectsList projects={projects} />}
+      </li>
+    );
+  },
+);
 
-      {projects && <ProjectsList projects={projects} />}
-    </li>
-  );
-}
+ContentItem.displayName = "ContentItem";
+
+export default ContentItem;

--- a/src/components/custom/ContentArea/ContentList.tsx
+++ b/src/components/custom/ContentArea/ContentList.tsx
@@ -1,5 +1,5 @@
 import { useBackground } from "@/contexts/BackgroundContext";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   createWheelHandler,
   resetScroll,
@@ -37,19 +37,57 @@ export function ContentList() {
   const contentListRef = useRef<HTMLUListElement>(null);
 
   // Refs for scroll state management
-  const isScrolling = useRef({ current: false }); // Flag to indicate if a scroll is in progress
-  const lastScrollTime = useRef({ current: 0 }); // Timestamp of the last scroll
-  const accumulatedDelta = useRef({ current: 0 }); // Accumulates deltaY to detect direction
+  const isScrolling = useRef(false); // Flag to indicate if a scroll is in progress
+  const lastScrollTime = useRef(0); // Timestamp of the last scroll
+  const accumulatedDelta = useRef(0); // Accumulates deltaY to detect direction
 
-  // Reset callback every time the year changes
+  // Refs for tracking individual ContentItem heights
+  const contentItemRefs = useRef<Record<string, HTMLLIElement | null>>({});
+  const [scrollHeight, setScrollHeight] = useState<number | null>(null);
+
+  // Reset scroll state every time the year changes
   useEffect(() => {
     registerScrollReset(() => {
       resetScroll(contentListRef);
-      isScrolling.current.current = false;
-      lastScrollTime.current.current = 0;
-      accumulatedDelta.current.current = 0;
+      isScrolling.current = false;
+      lastScrollTime.current = 0;
+      accumulatedDelta.current = 0;
     });
   }, [registerScrollReset]);
+
+  // Calculate bottom padding to enable scrolling based on ContentItem heights
+  useEffect(() => {
+    const calculateScrollPadding = () => {
+      // Get all item heights
+      const itemHeights = Object.values(contentItemRefs.current)
+        .filter((ref): ref is HTMLLIElement => ref !== null)
+        .map((ref) => ref.offsetHeight);
+
+      // If only one item, no scroll padding needed
+      if (itemHeights.length <= 1) {
+        setScrollHeight(null);
+        return;
+      }
+
+      // Calculate total height of all items
+      const totalHeight = itemHeights.reduce((sum, height) => sum + height, 0);
+
+      // Set padding to total height so items can scroll up fully
+      // This allows each item to reach the top of the container
+      setScrollHeight(totalHeight);
+    };
+
+    // Calculate after all items are rendered
+    calculateScrollPadding();
+
+    // Observe resize changes to recalculate
+    const resizeObserver = new ResizeObserver(calculateScrollPadding);
+    Object.values(contentItemRefs.current).forEach((ref) => {
+      if (ref) resizeObserver.observe(ref);
+    });
+
+    return () => resizeObserver.disconnect();
+  }, [yearContents]);
 
   // Effect to scroll when selectedContent changes (e.g., click on the bullet)
   useEffect(() => {
@@ -73,12 +111,20 @@ export function ContentList() {
     [goToNextContent, goToPreviousContent],
   );
 
+  // Helper to create ref callback for each ContentItem
+  const setItemRef = (itemId: string) => (el: HTMLLIElement | null) => {
+    contentItemRefs.current[itemId] = el;
+  };
+
   return (
     <ul
       ref={contentListRef}
       onWheel={handleWheel}
       className="content-list overflow-y-auto scroll-smooth hide-scrollbar"
-      style={{ scrollBehavior: "smooth" }}
+      style={{
+        scrollBehavior: "smooth",
+        paddingBottom: scrollHeight ? `${scrollHeight}px` : "0",
+      }}
     >
       {yearContents.map((period, index) => {
         const currentIndex = yearContents.findIndex(
@@ -94,6 +140,7 @@ export function ContentList() {
         return (
           <ContentItem
             key={period.id}
+            ref={setItemRef(period.id)}
             background={period}
             isNotUniqueOrLast={isNotUniqueOrLast}
             color={color}

--- a/src/components/custom/ContentArea/ContentList.tsx
+++ b/src/components/custom/ContentArea/ContentList.tsx
@@ -1,11 +1,16 @@
 import { useBackground } from "@/contexts/BackgroundContext";
 import { useCallback, useEffect, useRef } from "react";
-import { createWheelHandler, resetScroll, scrollToItem } from "./content-list.utils";
+import {
+  createWheelHandler,
+  resetScroll,
+  scrollToItem,
+} from "./content-list.utils";
 import ContentItem from "./ContentItem";
+import { CONTENT_VIEW_HEIGHT } from "./content-area.constants";
 
 const SCROLL_CONFIG = {
   THRESHOLD: 1,
-  TIME_RESET: 300
+  TIME_RESET: 300,
 } as const;
 
 /**
@@ -62,10 +67,10 @@ export function ContentList() {
         goToNextContent,
         goToPreviousContent,
         SCROLL_CONFIG.THRESHOLD, // Minimum accumulated deltaY threshold to navigate
-        SCROLL_CONFIG.TIME_RESET // Maximum time between scrolls to accumulate deltaY
+        SCROLL_CONFIG.TIME_RESET, // Maximum time between scrolls to accumulate deltaY
       )(event);
     },
-    [goToNextContent, goToPreviousContent]
+    [goToNextContent, goToPreviousContent],
   );
 
   return (
@@ -73,10 +78,12 @@ export function ContentList() {
       ref={contentListRef}
       onWheel={handleWheel}
       className="content-list overflow-y-auto scroll-smooth hide-scrollbar"
-      style={{ scrollBehavior: 'smooth' }}
+      style={{ scrollBehavior: "smooth" }}
     >
       {yearContents.map((period, index) => {
-        const currentIndex = yearContents.findIndex((item) => item.id === selectedContent);
+        const currentIndex = yearContents.findIndex(
+          (item) => item.id === selectedContent,
+        );
         const isLastItem = index === yearContents.length - 1;
         const isNotUniqueOrLast = yearContents.length > 1 && !isLastItem;
 
@@ -93,10 +100,10 @@ export function ContentList() {
             isNext={isNext}
             isPrevious={isPrevious}
             isLastItem={isLastItem}
-            containerHeight={290}
+            containerHeight={CONTENT_VIEW_HEIGHT}
           />
         );
       })}
     </ul>
-  )
+  );
 }

--- a/src/components/custom/ContentArea/DurationInfo.tsx
+++ b/src/components/custom/ContentArea/DurationInfo.tsx
@@ -3,7 +3,7 @@ import { HourglassIcon } from "@phosphor-icons/react";
 export default function DurationInfo({ durationInMonths }: { durationInMonths?: number }) {
   return (
     <div>
-      <div className="flex items-center pt-6 gap-2 text-sm">
+      <div className="flex items-center gap-2 text-sm">
         <HourglassIcon size={16} weight="duotone" />
         <span>{durationInMonths} months</span>
       </div>

--- a/src/components/custom/ContentArea/LocationInfo.tsx
+++ b/src/components/custom/ContentArea/LocationInfo.tsx
@@ -2,7 +2,7 @@ import { MapPinAreaIcon } from "@phosphor-icons/react";
 
 export default function LocationInfo({ location }: { location?: string }) {
   return (
-    <div className="flex items-center gap-2 pt-6 pb-2 text-sm">
+    <div className="flex items-center gap-2 mr-4 text-sm">
       <MapPinAreaIcon size={16} weight="duotone" />
       <span>{location}</span>
     </div>

--- a/src/components/custom/ContentArea/PeriodInfo.tsx
+++ b/src/components/custom/ContentArea/PeriodInfo.tsx
@@ -21,8 +21,12 @@ export default function PeriodInfo({
       </h2>
       <p className="text-sm max-w-[300px]">{description}</p>
 
-      {location && <LocationInfo location={location} />}
-      {durationInMonths && <DurationInfo durationInMonths={durationInMonths} />}
+      {(location || durationInMonths) && (
+        <div className="flex gap-2 mt-6">
+          {location && <LocationInfo location={location} />}
+          {durationInMonths && <DurationInfo durationInMonths={durationInMonths}/>}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/custom/ContentArea/content-area.constants.ts
+++ b/src/components/custom/ContentArea/content-area.constants.ts
@@ -1,0 +1,4 @@
+/**
+ * Shared constants for ContentArea component
+ */
+export const CONTENT_VIEW_HEIGHT = 230;

--- a/src/components/custom/ContentArea/content-item.types.ts
+++ b/src/components/custom/ContentArea/content-item.types.ts
@@ -3,7 +3,7 @@ import { Background, Project } from "@/background-data";
 export type ContentItemProps = {
   background: Background;
   isNotUniqueOrLast: boolean;
-  color: string;
+  color: ColorKey;
   isNext: boolean;
   isPrevious: boolean;
   isLastItem?: boolean;

--- a/src/components/custom/ContentArea/content-list.utils.ts
+++ b/src/components/custom/ContentArea/content-list.utils.ts
@@ -4,20 +4,18 @@ const SCROLL_ANIMATION_DURATION = 600;
 const DEFAULT_SCROLL_THRESHOLD = 10;
 const DEFAULT_SCROLL_TIME_RESET = 300;
 
-type MutableRef<T> = RefObject<{ current: T }>;
-
 /**
  * Scrolls to the selected item
  * Scrolls smoothly to a specific item within a scrollable container.
  *
  * @param {RefObject<HTMLUListElement | null>} contentListRef - Reference to the scrollable container element
  * @param {string} itemId - The ID of the element to scroll to
- * @param {RefObject<{ current: boolean }>} isScrollingRef - Reference to track if a scroll animation is in progress
+ * @param {RefObject<boolean>} isScrollingRef - Reference to track if a scroll animation is in progress
  */
 export function scrollToItem(
   contentListRef: RefObject<HTMLUListElement | null>,
   itemId: string,
-  isScrollingRef: MutableRef<boolean>
+  isScrollingRef: RefObject<boolean>
 ): void {
   const listElement = contentListRef.current;
   if (!listElement) return;
@@ -26,9 +24,7 @@ export function scrollToItem(
   if (!targetElement) return;
 
   // Prevent multiple scrolls at the same time (locks during animation)
-  if (isScrollingRef.current) {
-    isScrollingRef.current.current = true;
-  }
+  isScrollingRef.current = true;
 
   // Calculate the offset to scroll the element to the top of the container
   const containerRect = listElement.getBoundingClientRect();
@@ -43,9 +39,7 @@ export function scrollToItem(
 
   setTimeout(() => {
     // Allow scrolling again after animation (unlock)
-    if (isScrollingRef.current) {
-      isScrollingRef.current.current = false;
-    }
+    isScrollingRef.current = false;
   }, SCROLL_ANIMATION_DURATION);
 }
 
@@ -66,9 +60,9 @@ export function resetScroll(contentListRef: RefObject<HTMLUListElement | null>):
  * Creates a wheel event handler that simulates carousel-like navigation behavior.
  * Accumulates scroll deltas and triggers navigation callbacks when thresholds are met.
  *
- * @param {RefObject<{ current: boolean }>} isScrollingRef - Reference to track if navigation is in progress
- * @param {RefObject<{ current: number }>} lastScrollTimeRef - Reference to store the timestamp of the last scroll event
- * @param {RefObject<{ current: number }>} accumulatedDeltaRef - Reference to accumulate scroll deltas
+ * @param {RefObject<boolean>} isScrollingRef - Reference to track if navigation is in progress
+ * @param {RefObject<number>} lastScrollTimeRef - Reference to store the timestamp of the last scroll event
+ * @param {RefObject<number>} accumulatedDeltaRef - Reference to accumulate scroll deltas
  * @param {() => void} goToNext - Callback function to navigate to the next item
  * @param {() => void} goToPrevious - Callback function to navigate to the previous item
  * @param {number} [threshold=10] - Minimum accumulated delta required to trigger navigation
@@ -76,9 +70,9 @@ export function resetScroll(contentListRef: RefObject<HTMLUListElement | null>):
  * @returns {(e: React.WheelEvent<HTMLUListElement>) => void} Wheel event handler function
  */
 export function createWheelHandler(
-  isScrollingRef: MutableRef<boolean>,
-  lastScrollTimeRef: MutableRef<number>,
-  accumulatedDeltaRef: MutableRef<number>,
+  isScrollingRef: RefObject<boolean>,
+  lastScrollTimeRef: RefObject<number>,
+  accumulatedDeltaRef: RefObject<number>,
   goToNext: () => void,
   goToPrevious: () => void,
   threshold = DEFAULT_SCROLL_THRESHOLD,
@@ -88,27 +82,23 @@ export function createWheelHandler(
     e.preventDefault();
 
     // Prevent scroll during animation (locks during animation)
-    if (isScrollingRef.current?.current) return;
+    if (isScrollingRef.current) return;
 
     const now = Date.now();
-    const lastScrollTime = lastScrollTimeRef.current?.current || 0;
+    const lastScrollTime = lastScrollTimeRef.current;
 
     // Reset accumulator if too much time has passed since the last scroll
-    if (now - lastScrollTime > timeReset && accumulatedDeltaRef.current) {
-      accumulatedDeltaRef.current.current = 0;
+    if (now - lastScrollTime > timeReset) {
+      accumulatedDeltaRef.current = 0;
     }
 
     // Accumulate the deltaY to detect scroll direction
-    if (accumulatedDeltaRef.current) {
-      accumulatedDeltaRef.current.current += e.deltaY;
-    }
+    accumulatedDeltaRef.current += e.deltaY;
 
     // Update the last scroll time
-    if (lastScrollTimeRef.current) {
-      lastScrollTimeRef.current.current = now;
-    }
+    lastScrollTimeRef.current = now;
 
-    const accumulatedDelta = accumulatedDeltaRef.current?.current || 0;
+    const accumulatedDelta = accumulatedDeltaRef.current;
 
     // Navigate if the accumulated delta exceeds the threshold
     if (Math.abs(accumulatedDelta) >= threshold) {
@@ -119,9 +109,7 @@ export function createWheelHandler(
       }
 
       // Reset the accumulated delta after navigating
-      if (accumulatedDeltaRef.current) {
-        accumulatedDeltaRef.current.current = 0;
-      }
+      accumulatedDeltaRef.current = 0;
     }
   };
 }

--- a/src/contexts/BackgroundContext.tsx
+++ b/src/contexts/BackgroundContext.tsx
@@ -12,6 +12,7 @@ import React, {
 } from "react";
 import { contentData, Background } from "@/background-data";
 import { getRandomColor } from "@/components/custom/ContentArea/colors.utils";
+import { ColorKey } from "@/components/custom/ContentArea/content-item.types";
 
 type BackgroundContextType = {
   // State - primitives
@@ -22,7 +23,7 @@ type BackgroundContextType = {
 
   // State - complex objects
   initialContent: Background | null;
-  itemColors: Record<string, string>;
+  itemColors: Record<string, ColorKey>;
   yearContents: Background[];
 
   // Actions/callbacks
@@ -52,7 +53,7 @@ export function BackgroundProvider({
   );
 
   // ========== Refs ==========
-  const colorCacheRef = useRef<Record<string, string>>({});
+  const colorCacheRef = useRef<Record<string, ColorKey>>({});
   const scrollResetCallbackRef = useRef<(() => void) | null>(null);
 
   // ========== Memoized Values ==========
@@ -72,7 +73,7 @@ export function BackgroundProvider({
 
   // Generate colors for each ContentItem (cached to persist across year changes)
   const itemColors = useMemo(() => {
-    const colorMap: Record<string, string> = {};
+    const colorMap: Record<string, ColorKey> = {};
 
     yearContents.forEach((item) => {
       // Use cached color if exists, otherwise generate new one


### PR DESCRIPTION
_Don't forget to keep title's pattern: **[TURMA-<ISSUE_ID>] - Same title as issue**_

closes #44 

### 🚀 Description

A improvement point is that when the ContentItem is large, the lowest component part is cutted. Now `ContentList` height has the double size of all `ContentItem` height added together.

### 📷 Evidences

![turma44](https://github.com/user-attachments/assets/91af01b7-6bb5-43ec-bab9-0e02fc541d58)

## 🏷️ Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ☑️ Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
