### PR TITLE
[TURMA-00054] Background page - Deciding where to put Timeline in mobile devices

### DIFF
--- a/src/app/background/page.view.tsx
+++ b/src/app/background/page.view.tsx
@@ -14,7 +14,7 @@ export default function BackgroundPage() {
   const isDesktop = useMediaQuery("(min-width: 769px)");
 
   return (
-    <main className="user-page-grid grid my-auto min-h-screen">
+    <main className="user-page-grid grid h-screen overflow-hidden">
       {isDesktop ? (
         <UserInfoDesktop {...userData} />
       ) : (

--- a/src/app/background/page.view.tsx
+++ b/src/app/background/page.view.tsx
@@ -2,19 +2,16 @@
 
 import UserInfoDesktop from "../../components/custom/UserInfo/UserInfoDesktop";
 import UserInfoMobile from "../../components/custom/UserInfo/UserInfoMobile";
-import Timeline from "../../components/custom/Timeline";
+import Timeline from "../../components/custom/Timeline/Timeline";
 import "./styles.css";
-import { contentData, userData } from "@/background-data";
+import { userData } from "@/background-data";
 import { BackgroundProvider } from "../../contexts/BackgroundContext";
 import ContentArea from "@/components/custom/ContentArea/ContentArea";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
+import TimelineNavButtonsMobile from "@/components/custom/Timeline/TimelineNavButtonsMobile";
 
 export default function BackgroundPage() {
   const isDesktop = useMediaQuery("(min-width: 769px)");
-  
-  const backgroundYears = Array.from(
-    new Set(contentData.map((item) => item.year)),
-  );
 
   return (
     <main className="user-page-grid grid my-auto min-h-screen">
@@ -23,11 +20,10 @@ export default function BackgroundPage() {
       ) : (
         <UserInfoMobile {...userData} />
       )}
-      <BackgroundProvider
-        initialYear={backgroundYears.length > 0 ? backgroundYears[0] : null}
-      >
-        <Timeline years={backgroundYears} />
+      <BackgroundProvider>
+        <Timeline />
         <ContentArea />
+        {!isDesktop && <TimelineNavButtonsMobile />}
       </BackgroundProvider>
     </main>
   );

--- a/src/app/background/styles.css
+++ b/src/app/background/styles.css
@@ -2,9 +2,11 @@
   /* medium screens */
   .user-page-grid {
     grid-template-columns: 0.2fr 110px 0.2fr 1.8fr 0.2fr;
-    grid-template-rows: auto auto 1fr auto;
-    row-gap: 60px;
-    padding-top: 40px;
+    grid-template-rows: auto 1fr auto auto;
+    row-gap: 16px;
+    height: 100dvh;
+    padding-top: 24px;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
   }
 
   .user-container {
@@ -22,6 +24,7 @@
   .navigation-area {
     grid-column: 1 / 6;
     grid-row: 4 / 5;
+    padding: 12px 0;
   }
 }
 

--- a/src/app/background/styles.css
+++ b/src/app/background/styles.css
@@ -2,7 +2,7 @@
   /* medium screens */
   .user-page-grid {
     grid-template-columns: 0.2fr 110px 0.2fr 1.8fr 0.2fr;
-    grid-template-rows: auto auto 1fr;
+    grid-template-rows: auto auto 1fr auto;
     row-gap: 60px;
     padding-top: 40px;
   }
@@ -18,6 +18,10 @@
   .content-area {
     grid-column: 4 / 5;
     grid-row: 2 / 3;
+  }
+  .navigation-area {
+    grid-column: 1 / 6;
+    grid-row: 4 / 5;
   }
 }
 

--- a/src/components/custom/Timeline/Timeline.tsx
+++ b/src/components/custom/Timeline/Timeline.tsx
@@ -1,18 +1,20 @@
 "use client";
 
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { TimelineItemProps } from "./timeline.types";
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useBackground } from "../../../contexts/BackgroundContext";
 import YearButton from "./YearButton";
-import TimelineNavButtons from "./TimelineNavButtons";
 import BlackBorder from "./BlackBorder";
 import { useTimelineBlackBorder } from "../../../hooks/useTimelineBlackBorder";
 import { useTimelineNavigation } from "../../../hooks/useTimelineNavigation";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import TimelineNavButtonsDesktop from "./TimelineNavButtonsDesktop";
 
-export default function Timeline({ years }: TimelineItemProps) {
+export default function Timeline() {
+  const isDesktop = useMediaQuery("(min-width: 769px)");
+
   // Context
-  const { selectedYear, setSelectedYear } = useBackground();
+  const { selectedYear, setSelectedYear, registerTimelineNavigation, years } = useBackground();
 
   // Timeline refs
   const scrollViewportRef = useRef<HTMLDivElement | null>(null);
@@ -35,7 +37,7 @@ export default function Timeline({ years }: TimelineItemProps) {
       itemRefs,
     });
 
-  // Navigation logic
+  // Initialize timeline navigation handlers
   const {
     errorButton,
     handleUpAll,
@@ -49,6 +51,17 @@ export default function Timeline({ years }: TimelineItemProps) {
     scrollToYear,
     scrollViewportRef,
   });
+
+  // Register navigation handlers in context for mobile buttons outside Timeline
+  useEffect(() => {
+    registerTimelineNavigation({
+      errorButton,
+      handleUpAll,
+      handleDownAll,
+      handleUpOne,
+      handleDownOne,
+    });
+  }, [errorButton, handleUpAll, handleDownAll, handleUpOne, handleDownOne, registerTimelineNavigation]);
 
   return (
     <div className="timeline-container flex flex-col">
@@ -76,13 +89,10 @@ export default function Timeline({ years }: TimelineItemProps) {
           hasError={errorButton !== null}
         />
       </div>
-      <TimelineNavButtons
-        onUpAll={handleUpAll}
-        onUpOne={handleUpOne}
-        onDownAll={handleDownAll}
-        onDownOne={handleDownOne}
-        errorButton={errorButton}
-      />
+      { isDesktop &&
+        <TimelineNavButtonsDesktop />
+      }
+
     </div>
   );
 }

--- a/src/components/custom/Timeline/TimelineNavButtonsDesktop.tsx
+++ b/src/components/custom/Timeline/TimelineNavButtonsDesktop.tsx
@@ -6,22 +6,15 @@ import {
   ChevronsUpIcon,
   ChevronUpIcon,
 } from "lucide-react";
+import { useBackground } from "@/contexts/BackgroundContext";
 
-interface TimelineNavButtonsProps {
-  onUpAll: () => void;
-  onUpOne: () => void;
-  onDownAll: () => void;
-  onDownOne: () => void;
-  errorButton: string | null;
-}
+export default function TimelineNavButtonsDesktop() {
+  const { timelineNavigation } = useBackground();
 
-export default function TimelineNavButtons({
-  onUpAll,
-  onUpOne,
-  onDownAll,
-  onDownOne,
-  errorButton,
-}: TimelineNavButtonsProps) {
+  if (!timelineNavigation) return null;
+
+  const { errorButton, handleUpAll, handleUpOne, handleDownAll, handleDownOne } = timelineNavigation;
+
   const navButtonErrorStyle =
     "animate-pulse !border-red-400 !bg-red-100 !text-red-600";
 
@@ -32,7 +25,7 @@ export default function TimelineNavButtons({
           id="up-all"
           variant="outline"
           size="icon"
-          onClick={onUpAll}
+          onClick={handleUpAll}
           className={cn(errorButton === "up-all" && navButtonErrorStyle)}
         >
           <ChevronsUpIcon />
@@ -45,7 +38,7 @@ export default function TimelineNavButtons({
             "ml-2",
             errorButton === "up-one" && navButtonErrorStyle,
           )}
-          onClick={onUpOne}
+          onClick={handleUpOne}
         >
           <ChevronUpIcon />
         </Button>
@@ -55,7 +48,7 @@ export default function TimelineNavButtons({
           id="down-all"
           variant="outline"
           size="icon"
-          onClick={onDownAll}
+          onClick={handleDownAll}
           className={cn(errorButton === "down-all" && navButtonErrorStyle)}
         >
           <ChevronsDownIcon />
@@ -68,7 +61,7 @@ export default function TimelineNavButtons({
             "ml-2",
             errorButton === "down-one" && navButtonErrorStyle,
           )}
-          onClick={onDownOne}
+          onClick={handleDownOne}
         >
           <ChevronDownIcon />
         </Button>

--- a/src/components/custom/Timeline/TimelineNavButtonsMobile.tsx
+++ b/src/components/custom/Timeline/TimelineNavButtonsMobile.tsx
@@ -24,16 +24,16 @@ export default function TimelineNavButtonsMobile() {
         <Button
           id="up-all"
           variant="outline"
-          size="lg"
+          size="sm"
           onClick={handleUpAll}
           className={cn(errorButton === "up-all" && navButtonErrorStyle)}
         >
-          <ChevronsLeftIcon /> Primeiro
+          <ChevronsLeftIcon /> Prim.
         </Button>
         <Button
           id="up-one"
           variant="outline"
-          size="lg"
+          size="sm"
           className={cn(
             errorButton === "up-one" && navButtonErrorStyle,
           )}
@@ -46,7 +46,7 @@ export default function TimelineNavButtonsMobile() {
         <Button
           id="down-one"
           variant="outline"
-          size="lg"
+          size="sm"
           className={cn(
             errorButton === "down-one" && navButtonErrorStyle,
           )}
@@ -57,11 +57,11 @@ export default function TimelineNavButtonsMobile() {
         <Button
           id="down-all"
           variant="outline"
-          size="lg"
+          size="sm"
           onClick={handleDownAll}
           className={cn(errorButton === "down-all" && navButtonErrorStyle)}
         >
-          Último <ChevronsRightIcon />
+          Últ. <ChevronsRightIcon />
         </Button>
       </div>
     </div>

--- a/src/components/custom/Timeline/TimelineNavButtonsMobile.tsx
+++ b/src/components/custom/Timeline/TimelineNavButtonsMobile.tsx
@@ -19,8 +19,8 @@ export default function TimelineNavButtonsMobile() {
     "animate-pulse !border-red-400 !bg-red-100 !text-red-600";
 
   return (
-    <div className="navigation-area flex justify-center pb-12">
-      <div className="left-navigation flex mt-4 gap-4 mr-4">
+    <div className="navigation-area flex justify-center items-center bg-white h-fit z-10">
+      <div className="left-navigation flex gap-4 mr-4">
         <Button
           id="up-all"
           variant="outline"
@@ -42,7 +42,7 @@ export default function TimelineNavButtonsMobile() {
           Ant. <ChevronLeftIcon />
         </Button>
       </div>
-      <div className="right-navigation flex mt-4 gap-4">
+      <div className="right-navigation flex gap-4">
         <Button
           id="down-one"
           variant="outline"

--- a/src/components/custom/Timeline/TimelineNavButtonsMobile.tsx
+++ b/src/components/custom/Timeline/TimelineNavButtonsMobile.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ChevronsLeftIcon,
+  ChevronsRightIcon,
+} from "lucide-react";
+import { useBackground } from "@/contexts/BackgroundContext";
+
+export default function TimelineNavButtonsMobile() {
+  const { timelineNavigation } = useBackground();
+
+  if (!timelineNavigation) return null;
+
+  const { errorButton, handleUpAll, handleUpOne, handleDownAll, handleDownOne } = timelineNavigation;
+
+  const navButtonErrorStyle =
+    "animate-pulse !border-red-400 !bg-red-100 !text-red-600";
+
+  return (
+    <div className="navigation-area flex justify-center pb-12">
+      <div className="left-navigation flex mt-4 gap-4 mr-4">
+        <Button
+          id="up-all"
+          variant="outline"
+          size="lg"
+          onClick={handleUpAll}
+          className={cn(errorButton === "up-all" && navButtonErrorStyle)}
+        >
+          <ChevronsLeftIcon /> Primeiro
+        </Button>
+        <Button
+          id="up-one"
+          variant="outline"
+          size="lg"
+          className={cn(
+            errorButton === "up-one" && navButtonErrorStyle,
+          )}
+          onClick={handleUpOne}
+        >
+          Ant. <ChevronLeftIcon />
+        </Button>
+      </div>
+      <div className="right-navigation flex mt-4 gap-4">
+        <Button
+          id="down-one"
+          variant="outline"
+          size="lg"
+          className={cn(
+            errorButton === "down-one" && navButtonErrorStyle,
+          )}
+          onClick={handleDownOne}
+        >
+          Próx.<ChevronRightIcon />
+        </Button>
+        <Button
+          id="down-all"
+          variant="outline"
+          size="lg"
+          onClick={handleDownAll}
+          className={cn(errorButton === "down-all" && navButtonErrorStyle)}
+        >
+          Último <ChevronsRightIcon />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/custom/Timeline/timeline.types.ts
+++ b/src/components/custom/Timeline/timeline.types.ts
@@ -14,3 +14,11 @@ export type YearBtnLeftBulletProps = {
   isVisible: boolean;
   showError?: boolean;
 };
+
+export type TimelineNavButtonsProps = {
+  onUpAll: () => void;
+  onUpOne: () => void;
+  onDownAll: () => void;
+  onDownOne: () => void;
+  errorButton: string | null;
+}

--- a/src/components/custom/UserInfo/UserInfoMobile.tsx
+++ b/src/components/custom/UserInfo/UserInfoMobile.tsx
@@ -8,6 +8,7 @@ import AvatarAndName from "./AvatarAndName";
 export default function UserInfoMobile(userData: UserInfoProps) {
   return (
     <div id="user-info-mobile" className="user-container flex flex-col items-center justify-end">
+      <div id="top-padding" className="h-[20px]"></div> 
       <TopContainer {...userData} />
       <GrowingLine />
     </div>
@@ -33,7 +34,7 @@ function TopContainer({
   urls,
 }: UserInfoProps) {
   return (
-    <div className="md:w-fit flex items-center justify-center gap-8 md:mr-8">
+    <div className="flex items-center justify-center gap-8 md:w-fit md:mr-8">
       <AvatarAndName name={name} lastName={lastName} profilePhotoUrl={profilePhotoUrl} />
       <GoToSection goToUrls={urls} axis="vertical" />
     </div>

--- a/src/contexts/BackgroundContext.tsx
+++ b/src/contexts/BackgroundContext.tsx
@@ -14,6 +14,14 @@ import { contentData, Background } from "@/background-data";
 import { getRandomColor } from "@/components/custom/ContentArea/colors.utils";
 import { ColorKey } from "@/components/custom/ContentArea/content-item.types";
 
+export type TimelineNavigationHandlers = {
+  errorButton: string | null;
+  handleUpAll: () => void;
+  handleUpOne: () => void;
+  handleDownAll: () => void;
+  handleDownOne: () => void;
+};
+
 type BackgroundContextType = {
   // State - primitives
   canGoNext: boolean;
@@ -24,6 +32,7 @@ type BackgroundContextType = {
   // State - complex objects
   initialContent: Background | null;
   itemColors: Record<string, ColorKey>;
+  years: number[];
   yearContents: Background[];
 
   // Actions/callbacks
@@ -32,6 +41,10 @@ type BackgroundContextType = {
   registerScrollReset: (callback: () => void) => void;
   setSelectedContent: (contentId: string | null) => void;
   setSelectedYear: (year: number | null) => void;
+  
+  // Timeline navigation
+  registerTimelineNavigation: (handlers: TimelineNavigationHandlers) => void;
+  timelineNavigation: TimelineNavigationHandlers | null;
 };
 
 // Will be initialized in BackgroundProvider, if used outside will throw error
@@ -41,22 +54,28 @@ const BackgroundContext = createContext<BackgroundContextType | undefined>(
 
 export function BackgroundProvider({
   children,
-  initialYear = null,
 }: {
   children: ReactNode;
-  initialYear?: number | null;
 }) {
+  // ========== Memoized Values ==========
+  // Get all unique years from content data
+  const years = useMemo(() => {
+    return Array.from(new Set(contentData.map((item) => item.year)));
+  }, []);
+
   // ========== State ==========
   const [selectedContent, setSelectedContent] = useState<string | null>(null);
   const [selectedYear, setSelectedYear] = useState<number | null>(
-    initialYear ?? null,
+    years.length > 0 ? years[0] : null
   );
 
   // ========== Refs ==========
   const colorCacheRef = useRef<Record<string, ColorKey>>({});
   const scrollResetCallbackRef = useRef<(() => void) | null>(null);
+  const timelineNavigationRef = useRef<TimelineNavigationHandlers | null>(null);
+  const [timelineNavigation, setTimelineNavigation] = useState<TimelineNavigationHandlers | null>(null);
 
-  // ========== Memoized Values ==========
+  // ========== Derived State & Memoized Values ==========
   // Get content list for selected year, sorted by month (oldest first)
   const yearContents = useMemo(() => {
     if (selectedYear === null) return [];
@@ -108,6 +127,11 @@ export function BackgroundProvider({
     scrollResetCallbackRef.current = callback;
   }, []);
 
+  const registerTimelineNavigation = useCallback((handlers: TimelineNavigationHandlers) => {
+    timelineNavigationRef.current = handlers;
+    setTimelineNavigation(handlers);
+  }, []);
+
   const goToNextContent = useCallback(() => {
     if (canGoNext) {
       setSelectedContent(yearContents[currentIndex + 1].id);
@@ -147,6 +171,7 @@ export function BackgroundProvider({
         // State - complex objects
         initialContent,
         itemColors,
+        years,
         yearContents,
 
         // Actions/callbacks
@@ -155,6 +180,10 @@ export function BackgroundProvider({
         registerScrollReset,
         setSelectedContent,
         setSelectedYear,
+
+        // Timeline navigation
+        registerTimelineNavigation,
+        timelineNavigation,
       }}
     >
       {children}


### PR DESCRIPTION
_Don't forget to keep title's pattern: **[TURMA-<ISSUE_ID>] - Same title as issue**_

closes #54 

### 🚀 Description

This currently mobile layout is a little bit dysfunctional. The Timeline and ContentArea are competing for view space.
Side to side isn't the best approach to allow each part to shine in its own function.

Somehow, Timeline component should be moved to above or below of ContentArea. And TimelineNavigationButtons should be moved to bottom (to facilitate usability).

- extract timeline navigation into desktop and mobile variants
- display appropriate navigation based on device type (timeline navigation)
- adjust timeline types and exports to match the new structure
- update background page and styles to reflect the changes

### 📷 Evidences

Attach some prints, gifs or videos of the new change

## 🏷️ Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ☑️ Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
