### PR TITLE
[TURMA-00056][SUB-60] Move YearTitle and Timeline for new row on mobile devices

### DIFF
--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -1,12 +1,11 @@
 name: General Issue
 description: Feature, enhancement or general suggestion for the project
-title: "[TURMA-<ISSUE_NUMBER>] Title resuming the issue"
-labels: [enhancement, feature, frontend, backend, devops, documentation]
+title: "[TURMA-<ISSUE_ID>][SUB-<SUB_ISSUE_ID>] Title resuming the issue"
 
 body:
   - type: textarea
     attributes:
-      label: /## 🚀 Description
+      label: 🚀 Description
       placeholder: |
         You can describe with a clear and concise description of:
         * what the problem is
@@ -17,7 +16,7 @@ body:
 
   - type: textarea
     attributes:
-      label: /## 🧑‍💻 User stories
+      label: 🧑‍💻 User stories
       placeholder: |
         Describe user stories in the format:
         * As a [type of user], I want [goal] so that [reason/benefit]
@@ -27,11 +26,24 @@ body:
         * As a developer, I want to see code examples so that I can understand how to implement the feature
         * As an end user, I want a responsive interface so that I can access the app on any device
     validations:
-      required: true
+      required: false
 
   - type: textarea
     attributes:
-      label: /## 🥸 References / Attachments
+      label: 🥸 Technical Refinement
+      placeholder: |
+        You can describe technical details, considerations, or constraints related to the issue.
+        * Architecture changes
+        * Data models
+        * API endpoints
+        * Performance considerations
+        * Security implications
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: 📷 References / 🔗 Attachments
       placeholder: |
         You can attach some screenshots or links here.
         * Desktop

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-_Don't forget to keep title's pattern: **[TURMA-<ISSUE_ID>] - Same title as issue**_
+_Don't forget to keep title's pattern: **[TURMA-<ISSUE_ID>][SUB-<SUBISSUE_ID>] - Same title as issue OR as subissue **_
 
 closes #[issue_number]
 

--- a/src/app/background/page.view.tsx
+++ b/src/app/background/page.view.tsx
@@ -9,18 +9,18 @@ import { BackgroundProvider } from "../../contexts/BackgroundContext";
 import ContentArea from "@/components/custom/ContentArea/ContentArea";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import TimelineNavButtonsMobile from "@/components/custom/Timeline/TimelineNavButtonsMobile";
+import YearTitle from "@/components/custom/ContentArea/YearTitle";
 
 export default function BackgroundPage() {
   const isDesktop = useMediaQuery("(min-width: 769px)");
 
   return (
     <main className="user-page-grid grid h-screen overflow-hidden">
-      {isDesktop ? (
-        <UserInfoDesktop {...userData} />
-      ) : (
-        <UserInfoMobile {...userData} />
-      )}
+      {isDesktop ? <UserInfoDesktop {...userData} /> : <UserInfoMobile {...userData} />}
+
       <BackgroundProvider>
+        {!isDesktop && <YearTitle />}
+
         <Timeline />
         <ContentArea />
         {!isDesktop && <TimelineNavButtonsMobile />}

--- a/src/app/background/styles.css
+++ b/src/app/background/styles.css
@@ -1,8 +1,8 @@
 @media (max-width: 768px) {
   /* medium screens */
   .user-page-grid {
-    grid-template-columns: 0.2fr 110px 1.8fr 0.2fr;
-    grid-template-rows: auto 100px 1fr auto auto;
+    grid-template-columns: 2rem 1fr 252px 2rem;
+    grid-template-rows: auto 80px 1fr auto auto;
     height: 100dvh;
     padding-top: 24px;
     padding-bottom: env(safe-area-inset-bottom, 0px);
@@ -13,9 +13,17 @@
     grid-row: 1 / 2;
   }
   .timeline-area {
+    grid-column: 3 / 4;
+    grid-row: 2 / 3;
+    transform: rotate(-90deg) translateX(71px) translateY(-86px);
+    /* translateX translateY must be changed manualy and also you should checked at dev server if position is as wished */
+  }
+  .timeline-area .timeline {
+    height: 252px; /* this is inverted width = height but rotated -90deg. Must be multiple of 36px (yearBtn height) */
+  }
+  .year-title {
     grid-column: 2 / 3;
-    grid-row: 3 / 4;
-    display: none;
+    grid-row: 2 / 3;
   }
   .content-area {
     grid-column: 2 / 4;

--- a/src/components/custom/ContentArea/ContentArea.tsx
+++ b/src/components/custom/ContentArea/ContentArea.tsx
@@ -1,14 +1,17 @@
 "use client";
 
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 import BulletList from "./BulletList";
 import ContentList from "./ContentList";
 import YearTitle from "./YearTitle";
+import { cn } from "@/lib/utils";
 
 export default function ContentArea() {
+  const isDesktop = useMediaQuery("(min-width: 769px)");
 
   return (
-    <div className="content-area flex flex-col self-start md:pl-6 max-h-[290px] h-[290px]">
-      <YearTitle />
+    <div className={cn("content-area flex flex-col self-start md:pl-6 max-h-[290px] h-[290px]", !isDesktop && "mt-6")}>
+      {isDesktop && <YearTitle />}
 
       <div className="content-view flex justify-between max-h-[230px] h-[230px]">
         <ContentList />

--- a/src/components/custom/ContentArea/YearTitle.tsx
+++ b/src/components/custom/ContentArea/YearTitle.tsx
@@ -1,10 +1,13 @@
 import { useBackground } from "@/contexts/BackgroundContext";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { cn } from "@/lib/utils";
 
 export default function YearTitle() {
   const { selectedYear } = useBackground();
+  const isDesktop = useMediaQuery("(min-width: 769px)");
 
   return (
-    <h1 className="text-3xl pb-4 mb-6 sticky top-0 z-10 bg-white shadow-xs">
+    <h1 className={cn("year-title flex items-center text-3xl  sticky top-0 z-10 bg-white ", !isDesktop ? "pl-2" : "pb-4 mb-6 shadow-xs")}>
         {selectedYear}
       </h1>
   );

--- a/src/components/custom/Timeline/Timeline.tsx
+++ b/src/components/custom/Timeline/Timeline.tsx
@@ -9,6 +9,7 @@ import { useTimelineBlackBorder } from "../../../hooks/useTimelineBlackBorder";
 import { useTimelineNavigation } from "../../../hooks/useTimelineNavigation";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import TimelineNavButtonsDesktop from "./TimelineNavButtonsDesktop";
+import { cn } from "@/lib/utils";
 
 export default function Timeline() {
   const isDesktop = useMediaQuery("(min-width: 769px)");
@@ -67,7 +68,7 @@ export default function Timeline() {
     <div className="timeline-area flex flex-col">
       <div className="timeline flex ml-[5px]">
         <ScrollArea
-          className="z-1 scroll-area flex flex-col max-h-[290px]"
+          className={cn("scroll-area flex flex-col z-1", isDesktop && "max-h-[290px]")}
           viewportRef={scrollViewportRef}
           onViewportScroll={handleViewportScroll}
           hideScrollbar

--- a/src/components/custom/Timeline/YearButton.tsx
+++ b/src/components/custom/Timeline/YearButton.tsx
@@ -3,6 +3,7 @@ import { YearButtonProps } from "./timeline.types";
 import { suseMono } from "@/lib/fonts";
 import { cn } from "@/lib/utils";
 import YearBtnLeftBullet from "./YearBtnLeftBullet";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 export default function YearButton({
   year,
@@ -11,6 +12,7 @@ export default function YearButton({
   innerRef,
   showError = false,
 }: YearButtonProps) {
+  const isDesktop = useMediaQuery("(min-width: 769px)");
   const selectedStyle = "bg-accent";
   const errorStyle = "animate-pulse !bg-red-50 !text-red-600";
 
@@ -27,7 +29,8 @@ export default function YearButton({
         onClick={() => onClick(year)}
         aria-pressed={isSelected}
         className={cn(
-          "pr-[8px] rounded-none border-zinc-100 border-l-[3px] cursor-pointer hover:bg-accent",
+          "border-zinc-100 border-l-[3px] cursor-pointer hover:bg-accent rounded-none",
+          isDesktop ? "pr-[8px]" : "pr-[16px]",
           isSelected && selectedStyle,
           showError && errorStyle,
         )}

--- a/src/components/custom/UserInfo/UserInfoMobile.tsx
+++ b/src/components/custom/UserInfo/UserInfoMobile.tsx
@@ -22,7 +22,7 @@ function GrowingLine() {
         `w-full flex flex-col items-center justify-center`
       )}
     >
-      <div className="w-full h-[2px] mb-4 mt-6 border-b-[2px] border-b-zinc-200"></div>
+      <div className="w-full h-[2px] mt-4 border-b-[2px] border-b-zinc-200"></div>
     </div>
   );
 }


### PR DESCRIPTION
_Don't forget to keep title's pattern: **[TURMA-<ISSUE_ID>] - Same title as issue**_

closes #60 

### 🚀 Description

Implements a new grid-based layout for mobile screens with a rotated timeline component positioned between user info and content areas.

Key changes:
* Update mobile grid structure with fixed column widths (2rem, 1fr, 252px)
* Rotate timeline -90deg for horizontal display on mobile
* Add YearTitle component to timeline row on mobile
* Adjust spacing and positioning with transform offsets
* Make YearTitle responsive with conditional rendering
* Add padding adjustments for year buttons based on screen size
* Set fixed timeline height (252px) as multiple of year button height (36px)
* Adjust ContentArea top margin for mobile layout
* Update UserInfoMobile spacing for better visual alignment
* Remove max-height restriction on timeline ScrollArea for mobile

### 📷 Evidences

Attach some prints, gifs or videos of the new change

## 🏷️ Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ☑️ Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
