### PR TITLE
[PORT-00106][SUB-110] Create `FileTagLink` component

### DIFF
--- a/src/components/custom/showcase-page/FileTagLink.tsx
+++ b/src/components/custom/showcase-page/FileTagLink.tsx
@@ -1,0 +1,49 @@
+import { cn } from "@/lib/utils";
+import { CSSProperties } from "react";
+
+import { FileTagLinkProps } from "./showcase.types";
+
+/**
+ * Renders a clickable technology tag that opens the official documentation
+ * in a new tab.
+ *
+ * The link animation is staggered per item so the tag list does not pulse
+ * in sync when multiple tags are rendered together.
+ */
+export default function FileTagLink({
+  language,
+  index,
+  tagStepSeconds,
+  tagCycleSeconds,
+}: FileTagLinkProps) {
+  console.log(language);
+  const { style, link, label } = language;
+
+  return (
+    <li
+      className={cn(
+        "list-none px-3 py-1 rounded-md text-[13px] font-bold font-mono tracking-wider border-transparent border-1",
+        style,
+      )}
+    >
+      <a
+        href={link}
+        target="_blank"
+        rel="noreferrer"
+        className={cn(
+          "no-underline text-inherit inline-block animate-pulse animation-fill-mode:both ",
+        )}
+        style={
+          {
+            // Offset each tag pulse so repeated tags animate with a stagger.
+            animationDelay: `${index * tagStepSeconds}s`,
+            animationDuration: `${tagCycleSeconds}s`,
+          } as CSSProperties
+        }
+        aria-label={`Abrir documentacao de ${label}`}
+      >
+        .{label}
+      </a>
+    </li>
+  );
+}


### PR DESCRIPTION
_Don't forget to keep title's pattern:_

- _Issue PR: **[TURMA-<ISSUE_ID>] + title (PR #<PR_NUMBER>)**_
- _Sub-issue PR: **[TURMA-<ISSUE_ID>][SUB-<SUBISSUE_ID>] + title (PR #<PR_NUMBER>)**_

_Base branch:_

- _Issue PR → `dev`_
- _Sub-issue PR → parent issue branch (`feat/TURMA-<ISSUE_ID>`)_

closes #110

### 🚀 Description

This pull request introduces a new `FileTagLink` component to render clickable technology tags with animated, staggered pulses.

New component addition:

* Added `FileTagLink` component in `src/components/custom/showcase-page/FileTagLink.tsx` to display technology tags as animated links that open official documentation in a new tab, with staggered animation timing for each tag .

### 📷 Evidences

<img width="232" height="59" alt="Captura de Tela 2026-06-20 às 18 55 59" src="https://github.com/user-attachments/assets/5a45ac7d-5b20-4a0b-8579-286a5543ab69" />

## 🏷️ Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ☑️ Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
