### PR TITLE
[PORT-00106][SUB-111] Create `LanguageStackLink` component

### DIFF
--- a/src/components/custom/showcase-page/LanguageStackList.tsx
+++ b/src/components/custom/showcase-page/LanguageStackList.tsx
@@ -1,0 +1,49 @@
+import { FILES_LIST } from "@/showcase-data";
+import FileTagLink from "./FileTagLink";
+import { LanguageStackListProps } from "./showcase.types";
+import { cn } from "@/lib/utils";
+import { changaSans } from "@/lib/fonts";
+import { CodeXml } from "lucide-react";
+
+export default function LanguageStackList({
+  languageStack,
+}: LanguageStackListProps) {
+  const hasLanguageStack = languageStack && languageStack.length > 0;
+  const tagCycleSeconds = 1.8;
+  const tagStepSeconds = hasLanguageStack
+    ? tagCycleSeconds / languageStack.length
+    : 0;
+
+  console.log("languageStack", languageStack);
+  if (!hasLanguageStack) {
+    return null;
+  }
+
+  return (
+    <>
+      <h4
+        className={cn(
+          "flex w-fit items-center text-[1rem] font-weight-[700] mb-4 text-black tracking-wide",
+          changaSans.className,
+        )}
+      >
+        <CodeXml size={16} className="mr-2" />
+        Linguagens / Extensões
+      </h4>
+      <ul
+        className="flex flex-wrap gap-2.5 mb-10"
+        aria-label="Lista de linguagens utilizadas"
+      >
+        {languageStack.map((tag, index) => (
+          <FileTagLink
+            key={crypto.randomUUID()}
+            language={FILES_LIST[tag]}
+            index={index}
+            tagStepSeconds={tagStepSeconds}
+            tagCycleSeconds={tagCycleSeconds}
+          />
+        ))}
+      </ul>
+    </>
+  );
+}


### PR DESCRIPTION
_Don't forget to keep title's pattern:_

- _Issue PR: **[TURMA-<ISSUE_ID>] + title (PR #<PR_NUMBER>)**_
- _Sub-issue PR: **[TURMA-<ISSUE_ID>][SUB-<SUBISSUE_ID>] + title (PR #<PR_NUMBER>)**_

_Base branch:_

- _Issue PR → `dev`_
- _Sub-issue PR → parent issue branch (`feat/TURMA-<ISSUE_ID>`)_

closes #111

### 🚀 Description

This pull request introduces a new `LanguageStackList` component to display a list of languages/extensions used in a showcase. The component adds a styled section with an icon and dynamically renders language tags using the `FileTagLink` component.

**New component for language stack display:**

* Added `LanguageStackList` component in `LanguageStackList.tsx` to render a styled list of languages/extensions with a section header and icon.
* Integrates `FileTagLink` for each language, passing timing props for potential animation or display logic.
* Utilizes utility functions and constants such as `FILES_LIST`, `cn`, and `changaSans` for data and styling.
* Includes accessibility improvements by setting `aria-label` on the list.

### 📷 Evidences

<img width="259" height="87" alt="image" src="https://github.com/user-attachments/assets/5152f1a3-c06c-454e-9642-73a23739350d" />

## 🏷️ Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ☑️ Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
