### PR TITLE
[PORT-106][SUB-112] Create `ProjectInfoButtons` component

### DIFF
--- a/src/components/custom/showcase-page/LanguageStackList.tsx
+++ b/src/components/custom/showcase-page/LanguageStackList.tsx
@@ -5,11 +5,19 @@ import { cn } from "@/lib/utils";
 import { changaSans } from "@/lib/fonts";
 import { CodeXml } from "lucide-react";
 
+/**
+ * Renders the project language/extension tags with a staggered pulse animation.
+ *
+ * The list keeps a fixed cycle duration and distributes each tag delay across
+ * the total number of items so cadence remains consistent.
+ */
 export default function LanguageStackList({
   languageStack,
 }: LanguageStackListProps) {
   const hasLanguageStack = languageStack && languageStack.length > 0;
+  // Fixed loop duration for the full tag animation set.
   const tagCycleSeconds = 1.8;
+  // Stagger each tag evenly inside the cycle.
   const tagStepSeconds = hasLanguageStack
     ? tagCycleSeconds / languageStack.length
     : 0;
@@ -34,6 +42,7 @@ export default function LanguageStackList({
         className="flex flex-wrap gap-2.5 mb-10"
         aria-label="Lista de linguagens utilizadas"
       >
+        {/* Render each tag with delayed pulse so items do not animate in sync. */}
         {languageStack.map((tag, index) => (
           <FileTagLink
             key={crypto.randomUUID()}

--- a/src/components/custom/showcase-page/ProjectInfoButtons.tsx
+++ b/src/components/custom/showcase-page/ProjectInfoButtons.tsx
@@ -1,0 +1,45 @@
+import { Button } from "@/components/ui/button";
+import { ExternalLink, Plus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { ProjectInfoButtonsProps } from "./showcase.types";
+
+/**
+ * Renders action buttons for each project card.
+ *
+ * - "Mais detalhes" navigates to the project details route.
+ * - "Visitar site" is shown only when a live URL is available.
+ */
+export default function ProjectInfoButtons({
+  slug,
+  webLink,
+}: ProjectInfoButtonsProps) {
+  const router = useRouter();
+
+  return (
+    <footer className="project-info-buttons">
+      <Button
+        // Internal navigation to the showcase details page.
+        onClick={() => router.push(`/showcase/${slug}`)}
+        data-icon="inline-start"
+        size="lg"
+        className="mr-4 text-md cursor-pointer hover:scale-105 hover:shadow-md transition-all duration-300"
+      >
+        <Plus />
+        Mais detalhes
+      </Button>
+      {webLink && (
+        <Button
+          // Navigate to the project's live site when provided.
+          onClick={() => router.push(webLink)}
+          variant="link"
+          data-icon="inline-start"
+          size="lg"
+          className="text-md  cursor-pointer hover:scale-105 transition-all duration-300"
+        >
+          <ExternalLink />
+          Visitar site
+        </Button>
+      )}
+    </footer>
+  );
+}


### PR DESCRIPTION
_Don't forget to keep title's pattern:_

- _Issue PR: **[TURMA-<ISSUE_ID>] + title (PR #<PR_NUMBER>)**_
- _Sub-issue PR: **[TURMA-<ISSUE_ID>][SUB-<SUBISSUE_ID>] + title (PR #<PR_NUMBER>)**_

_Base branch:_

- _Issue PR → `dev`_
- _Sub-issue PR → parent issue branch (`feat/TURMA-<ISSUE_ID>`)_

closes #112 

### 🚀 Description

Introduces a new `ProjectInfoButtons` component to handle project card actions in a more modular way.

**Component extraction and new features:**

* Added a new `ProjectInfoButtons` component to render action buttons on project cards, including navigation to project details and an optional external site link. This component uses the Next.js router for client-side navigation and conditionally displays the "Visitar site" button only when a live URL is provided. (`src/components/custom/showcase-page/ProjectInfoButtons.tsx`)

**Documentation and code clarity:**

* Added inline comments in `LanguageStackList` to clarify the animation logic and the rendering of tags with staggered pulse effects. (`src/components/custom/showcase-page/LanguageStackList.tsx`)

### 📷 Evidences

<img width="327" height="66" alt="image" src="https://github.com/user-attachments/assets/b621c59d-20d5-4c91-a11d-9cdb7a6ed8a0" />

## 🏷️ Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ☑️ Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
