### PR TITLE
 [PORT-00106][SUB-113] Create `ProjectItemInfo` component

### DIFF
--- a/src/components/custom/showcase-page/ProjectItemInfo.tsx
+++ b/src/components/custom/showcase-page/ProjectItemInfo.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/lib/utils";
+import LanguageStackList from "./LanguageStackList";
+import ProjectInfoButtons from "./ProjectInfoButtons";
+import { ProjectItemInfoProps } from "./showcase.types";
+import { courstardSans } from "@/lib/fonts";
+
+export default function ProjectItemInfo({
+  title,
+  slug,
+  category,
+  description,
+  languageStack,
+  className,
+  webLink,
+}: ProjectItemInfoProps) {
+  const hasLanguageStack = languageStack && languageStack.length > 0;
+
+  return (
+    <section
+      className={cn("project-item-info", className)}
+      aria-label={`Detalhes do projeto ${title}`}
+    >
+      <h3 className="text-3xl font-bold mb-6 tracking-tight text-gray-900 flex items-center gap-3 flex-wrap">
+        {title}
+        <span className="text-gray-400 font-medium tracking-normal text-2xl">
+          [{category}]
+        </span>
+      </h3>
+
+      <p
+        className={cn(
+          "text-gray-500 mb-8 max-w-lg leading-[1.8] whitespace-pre-line text-[15px]",
+          courstardSans.className,
+        )}
+      >
+        {description}
+      </p>
+
+      {hasLanguageStack && <LanguageStackList languageStack={languageStack} />}
+
+      <ProjectInfoButtons slug={slug} webLink={webLink} />
+    </section>
+  );
+}

--- a/src/components/custom/showcase-page/ProjectItemInfo.tsx
+++ b/src/components/custom/showcase-page/ProjectItemInfo.tsx
@@ -4,6 +4,12 @@ import ProjectInfoButtons from "./ProjectInfoButtons";
 import { ProjectItemInfoProps } from "./showcase.types";
 import { courstardSans } from "@/lib/fonts";
 
+/**
+ * Renders the textual details for a project item.
+ *
+ * Includes title/category, description, optional language tags,
+ * and the primary action buttons.
+ */
 export default function ProjectItemInfo({
   title,
   slug,
@@ -36,6 +42,7 @@ export default function ProjectItemInfo({
         {description}
       </p>
 
+      {/* Show language tags only when the project has a stack defined. */}
       {hasLanguageStack && <LanguageStackList languageStack={languageStack} />}
 
       <ProjectInfoButtons slug={slug} webLink={webLink} />


### PR DESCRIPTION
_Don't forget to keep title's pattern:_

- _Issue PR: **[TURMA-<ISSUE_ID>] + title (PR #<PR_NUMBER>)**_
- _Sub-issue PR: **[TURMA-<ISSUE_ID>][SUB-<SUBISSUE_ID>] + title (PR #<PR_NUMBER>)**_

_Base branch:_

- _Issue PR → `dev`_
- _Sub-issue PR → parent issue branch (`feat/TURMA-<ISSUE_ID>`)_

closes #113 

### 🚀 Description

This pull request adds a new `ProjectItemInfo` component to the codebase. The component is responsible for displaying detailed information about a project, including its title, category, description, technology stack, and action buttons.

Component addition:

* Added a new `ProjectItemInfo` component in `ProjectItemInfo.tsx` that renders the project title, category, description, language stack (if available), and project-related buttons.
* Integrated utility functions (`cn` for classnames), custom fonts (`courstardSans`), and subcomponents (`LanguageStackList`, `ProjectInfoButtons`) to structure and style the project information display.

### 📷 Evidences

<img width="432" height="406" alt="image" src="https://github.com/user-attachments/assets/53473fd2-57db-4e05-9292-73e68c066ac7" />


## 🏷️ Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ☑️ Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
