### PR TITLE
 [PORT-00106][SUB-114] Create `ProjectItemImage` component

### DIFF
--- a/src/components/custom/showcase-page/ProjectItemImage.tsx
+++ b/src/components/custom/showcase-page/ProjectItemImage.tsx
@@ -1,0 +1,36 @@
+import { env } from "@/env";
+import { cn } from "@/lib/utils";
+import { ProjectItemImageProps } from "./showcase.types";
+
+/**
+ * Renders the project preview image using the first available screenshot.
+ *
+ * Transparent images keep a clean background, while non-transparent images
+ * get a framed card treatment for better contrast.
+ */
+export default function ProjectItemImage({
+  images,
+  title,
+  className,
+}: ProjectItemImageProps) {
+  const s3BucketUrl = env.NEXT_PUBLIC_S3_BUCKET_URL;
+
+  // The showcase uses the first image as the main preview.
+  const img = images[0];
+
+  // Transparent assets should blend with the page background.
+  const transparentBgStyle = img.isTransparent
+    ? "bg-transparent"
+    : "border-2 border-white shadow-lg rounded-lg";
+
+  return (
+    <figure className={className}>
+      <img
+        // Images are stored in S3 and served from the configured bucket URL.
+        src={`${s3BucketUrl}/${img.src}`}
+        alt={`${title} screenshot`}
+        className={cn("project-item-image object-cover ", transparentBgStyle)}
+      />
+    </figure>
+  );
+}


### PR DESCRIPTION
_Don't forget to keep title's pattern:_

- _Issue PR: **[TURMA-<ISSUE_ID>] + title (PR #<PR_NUMBER>)**_
- _Sub-issue PR: **[TURMA-<ISSUE_ID>][SUB-<SUBISSUE_ID>] + title (PR #<PR_NUMBER>)**_

_Base branch:_

- _Issue PR → `dev`_
- _Sub-issue PR → parent issue branch (`feat/TURMA-<ISSUE_ID>`)_

closes #114 

### 🚀 Description

This pull request adds a new `ProjectItemImage` component to the codebase, which is responsible for rendering project preview images with appropriate styling based on image transparency. 

New component for project images:

* Added `ProjectItemImage` component in `src/components/custom/showcase-page/ProjectItemImage.tsx` to render the main project preview image, dynamically styling images based on their transparency and sourcing them from the configured **S3 bucket URL**.

### 📷 Evidences

<img width="441" height="491" alt="image" src="https://github.com/user-attachments/assets/f6152bdd-df3b-4e49-a21b-3b9288a5508b" />

## 🏷️ Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ☑️ Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
