### PR TITLE
[PORT-00106][SUB-117] Create ProjectItem component

### DIFF
--- a/src/components/custom/showcase-page/ProjectItem.tsx
+++ b/src/components/custom/showcase-page/ProjectItem.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { numberToMonthPTBR } from "@/lib/utils";
+import { Project } from "@/showcase-data";
+
+import YearAndMonth from "./YearAndMonth";
+import ProjectItemInfo from "./ProjectItemInfo";
+import ProjectItemImage from "./ProjectItemImage";
+
+export function ProjectItem({ project }: { project: Project }) {
+  const {
+    year,
+    month,
+    images,
+    title,
+    category,
+    description,
+    languageStack,
+    slug,
+    links,
+  } = project;
+
+  const hasLanguageStack = languageStack && languageStack.length > 0;
+
+  const webLink = links.find((link) => link.type === "web")?.url ?? "#";
+
+  return (
+    <article className="project-item flex flex-col">
+      <header className="flex items-center mb-6 relative z-20">
+        <YearAndMonth year={year} month={numberToMonthPTBR(month)} />
+      </header>
+
+      <section className="flex w-full flex-col items-start gap-8 md:gap-16 lg:flex-row pl-10 py-4 border-l-2 border-gray-50">
+        <ProjectItemImage
+          images={images}
+          title={title}
+          className="flex justify-center self-center w-[380px]"
+        />
+
+        <ProjectItemInfo
+          title={title}
+          slug={slug}
+          category={category}
+          description={description}
+          languageStack={hasLanguageStack ? languageStack : undefined}
+          webLink={webLink}
+          className="flex flex-col flex-1 pt-4 lg:pt-8 relative z-20 min-w-[300px] md:min-w-[380px] max-w-[380px]"
+        />
+      </section>
+    </article>
+  );
+}

--- a/src/components/custom/showcase-page/showcase.types.ts
+++ b/src/components/custom/showcase-page/showcase.types.ts
@@ -1,0 +1,39 @@
+import { FileTag, ImageInfo } from "@/showcase-data";
+
+export type YearAndMonthProps = {
+  year: number;
+  month: string;
+};
+
+export type ProjectItemInfoProps = {
+  title: string;
+  slug: string;
+  category: string;
+  description: string;
+  languageStack?: string[];
+  className?: string;
+  webLink?: string;
+};
+
+export type ProjectItemImageProps = {
+  images: ImageInfo[];
+  title: string;
+  className?: string;
+};
+
+export type LanguageStackListProps = {
+  languageStack: string[];
+};
+
+export type FileTagLinkProps = {
+  key: string;
+  index: number;
+  language: FileTag;
+  tagStepSeconds: number;
+  tagCycleSeconds: number;
+};
+
+export type ProjectInfoButtonsProps = {
+  slug: string;
+  webLink?: string;
+};


### PR DESCRIPTION
_Don't forget to keep title's pattern:_

- _Issue PR: **[TURMA-<ISSUE_ID>] + title (PR #<PR_NUMBER>)**_
- _Sub-issue PR: **[TURMA-<ISSUE_ID>][SUB-<SUBISSUE_ID>] + title (PR #<PR_NUMBER>)**_

_Base branch:_

- _Issue PR → `dev`_
- _Sub-issue PR → parent issue branch (`feat/TURMA-<ISSUE_ID>`)_

closes #117 

### 🚀 Description

This pull request introduces the new `ProjectItem` component for the showcase page and defines supporting TypeScript types to improve type safety and code organization.

**New Project Item Component:**

* Added the `ProjectItem` React component to display project details, including images, title, description, technology stack, and links, using composition of smaller components (`YearAndMonth`, `ProjectItemInfo`, `ProjectItemImage`). 

**Type Definitions:**

* Introduced several TypeScript types to describe the props for the new and existing showcase components, such as `YearAndMonthProps`, `ProjectItemInfoProps`, `ProjectItemImageProps`, and others, to ensure strong typing and easier maintenance. (`src/components/custom/showcase-page/showcase.types.ts`)

### 📷 Evidences

Attach some prints, gifs or videos of the new change

## 🏷️ Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ☑️ Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
